### PR TITLE
Fix dashboard streak not refreshing after logging progress

### DIFF
--- a/app/api/books/[id]/progress/[progressId]/route.ts
+++ b/app/api/books/[id]/progress/[progressId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { ProgressService } from "@/lib/services/progress.service";
 import { progressRepository } from "@/lib/repositories";
 
@@ -41,6 +42,9 @@ export async function PATCH(
     };
 
     const updatedEntry = await progressService.updateProgress(progressId, updateData);
+
+    // Revalidate the dashboard to update streak data
+    revalidatePath('/');
 
     return NextResponse.json(updatedEntry);
   } catch (error: any) {
@@ -102,6 +106,9 @@ export async function DELETE(
     if (!success) {
       return NextResponse.json({ error: "Failed to delete progress entry" }, { status: 500 });
     }
+
+    // Revalidate the dashboard to update streak data
+    revalidatePath('/');
 
     return NextResponse.json({ success: true, message: "Progress entry deleted" });
   } catch (error) {

--- a/app/api/books/[id]/progress/route.ts
+++ b/app/api/books/[id]/progress/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { ProgressService } from "@/lib/services/progress.service";
 
 export const dynamic = 'force-dynamic';
@@ -62,6 +63,9 @@ export async function POST(
     };
 
     const progressLog = await progressService.logProgress(bookId, progressData);
+
+    // Revalidate the dashboard to update streak data
+    revalidatePath('/');
 
     return NextResponse.json(progressLog);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fixes bug where dashboard streak and stats display stale data when navigating back after logging progress on book detail page
- Adds cache revalidation to progress API endpoints (POST, PATCH, DELETE) to ensure dashboard data refreshes automatically

## Changes
- Added `revalidatePath('/')` calls to progress creation, update, and deletion endpoints
- Dashboard now shows updated streak, pages read today, and other stats immediately when navigating back from book detail page

## Testing
- Log progress on a book detail page
- Navigate back to dashboard using browser back button or navigation link
- Verify streak flame icon, pages today, and other stats reflect the new progress without requiring a manual page reload