### PR TITLE
Fix dashboard not updating after book status and rating changes

### DIFF
--- a/app/api/books/[id]/rating/route.ts
+++ b/app/api/books/[id]/rating/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { BookService } from "@/lib/services/book.service";
 
 export const dynamic = 'force-dynamic';
@@ -65,6 +66,9 @@ export async function POST(
     }
     
     const updatedBook = await bookService.updateRating(bookId, rating ?? null);
+    
+    // Revalidate the dashboard to update book rating display
+    revalidatePath('/');
     
     return NextResponse.json(updatedBook);
   } catch (error) {

--- a/app/api/books/[id]/reread/route.ts
+++ b/app/api/books/[id]/reread/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { SessionService } from "@/lib/services/session.service";
 import { sessionRepository } from "@/lib/repositories";
 
@@ -51,6 +52,9 @@ export async function POST(
     const lastSession = await sessionRepository.findLatestByBookId(bookId);
 
     const newSession = await sessionService.startReread(bookId);
+
+    // Revalidate the dashboard to update book status display
+    revalidatePath('/');
 
     return NextResponse.json({
       message: "Re-reading session started successfully",

--- a/app/api/books/[id]/status/route.ts
+++ b/app/api/books/[id]/status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 import { SessionService } from "@/lib/services/session.service";
 
 export const dynamic = 'force-dynamic';
@@ -54,6 +55,9 @@ export async function POST(
     };
 
     const result = await sessionService.updateStatus(bookId, statusData);
+
+    // Revalidate the dashboard to update book status display
+    revalidatePath('/');
 
     // Return full result if session was archived, otherwise just the session
     if (result.sessionArchived) {


### PR DESCRIPTION
## Summary
- Fixes bug where dashboard doesn't automatically reflect book status changes when modified on the book detail page
- Adds cache revalidation to status, reread, and rating API endpoints using the same proven pattern from progress updates (commit 92ed7dd)

## Changes
- Added `revalidatePath('/')` to `/api/books/[id]/status` endpoint
- Added `revalidatePath('/')` to `/api/books/[id]/reread` endpoint  
- Added `revalidatePath('/')` to `/api/books/[id]/rating` endpoint

## Testing
- Changes follow exact pattern already working for progress updates
- No new TypeScript errors introduced
- Ensures dashboard updates automatically when:
  - Changing book status (e.g., reading → read)
  - Starting a re-read
  - Adding/updating book rating

## Related
Resolves the dashboard sync issue - no more hard refresh needed to see status changes!