### PR TITLE
Fix series list page not displaying series with empty string filter

### DIFF
--- a/__tests__/repositories/series.repository.test.ts
+++ b/__tests__/repositories/series.repository.test.ts
@@ -100,6 +100,37 @@ describe("SeriesRepository", () => {
       const series = await seriesRepository.getAllSeries();
       expect(series).toHaveLength(0);
     });
+
+    it("should exclude books with empty string series", async () => {
+      // Create books with valid series
+      await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+        series: "Series A",
+        seriesIndex: 1,
+      });
+
+      // Create book with empty string series (as Calibre might export)
+      await bookRepository.create({
+        calibreId: 2,
+        title: "Book 2",
+        authors: ["Author 2"],
+        tags: [],
+        path: "/path/2",
+        series: "",
+        seriesIndex: null,
+      });
+
+      const series = await seriesRepository.getAllSeries();
+
+      // Should only return Series A, not the empty string
+      expect(series).toHaveLength(1);
+      expect(series[0].name).toBe("Series A");
+      expect(series[0].bookCount).toBe(1);
+    });
   });
 
   describe("getBooksBySeries", () => {

--- a/lib/repositories/series.repository.ts
+++ b/lib/repositories/series.repository.ts
@@ -64,6 +64,7 @@ export class SeriesRepository extends BaseRepository<
       .where(
         and(
           isNotNull(books.series),
+          sql`${books.series} != ''`,  // Exclude empty strings (Calibre may use '' instead of NULL)
           eq(books.orphaned, false)
         )
       )


### PR DESCRIPTION
## Summary
- Fixes critical bug where the series list page (`/series`) shows "no series found" even when series data exists
- Root cause: `getAllSeries()` only filtered NULL series values, but Calibre databases contain books with empty string ('') series values  
- Individual series detail pages worked because they use exact name matching instead of NULL filtering

## Changes
- Updated series repository `getAllSeries()` query to exclude both NULL and empty string series values
- Added test case to verify empty string filtering behavior

## Testing
- All existing tests pass
- New test case validates that books with empty string series are excluded from results
- Verified the fix resolves the production issue where series list page was empty

Closes production bug reported by user where series entries appeared on book logs but not on the series page.