### PR TITLE
Fix series API caching issue and add debug logging

### DIFF
--- a/app/api/series/route.ts
+++ b/app/api/series/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { seriesService } from "@/lib/services/series.service";
 
+// Force dynamic rendering to prevent caching
+export const dynamic = 'force-dynamic';
+
 /**
  * GET /api/series
  * Get all series in the library

--- a/lib/repositories/series.repository.ts
+++ b/lib/repositories/series.repository.ts
@@ -50,7 +50,11 @@ export class SeriesRepository extends BaseRepository<
    * @returns Array of series info objects
    */
   async getAllSeries(): Promise<SeriesInfo[]> {
+    const { getLogger } = require("@/lib/logger");
+    const logger = getLogger();
     const db = this.getDatabase();
+
+    logger.debug("[SeriesRepository.getAllSeries] Starting query");
 
     // Fetch all books with series in a single query, ordered by series and seriesIndex
     const allBooks = await db
@@ -69,6 +73,11 @@ export class SeriesRepository extends BaseRepository<
         )
       )
       .orderBy(asc(books.series), asc(books.seriesIndex), asc(books.title));
+
+    logger.info({ bookCount: allBooks.length }, `[SeriesRepository.getAllSeries] Found ${allBooks.length} books with series`);
+    if (allBooks.length > 0) {
+      logger.debug({ firstBook: allBooks[0] }, "[SeriesRepository.getAllSeries] First book");
+    }
 
     // Group books by series and extract first 3 covers in-memory (much faster than N queries)
     const seriesMap = new Map<string, { bookCount: number; bookCoverIds: number[] }>();
@@ -90,11 +99,18 @@ export class SeriesRepository extends BaseRepository<
     }
 
     // Convert map to array format
-    return Array.from(seriesMap.entries()).map(([name, data]) => ({
+    const result = Array.from(seriesMap.entries()).map(([name, data]) => ({
       name,
       bookCount: data.bookCount,
       bookCoverIds: data.bookCoverIds,
     }));
+
+    logger.info({ seriesCount: result.length }, `[SeriesRepository.getAllSeries] Returning ${result.length} series`);
+    if (result.length > 0) {
+      logger.debug({ firstSeries: result[0] }, "[SeriesRepository.getAllSeries] First series");
+    }
+
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes production issue where series list API returns empty results despite database containing series data
- Root cause: Next.js 14 caches GET route handlers by default, serving stale empty results from initial deployment

## Root Cause Analysis
After thorough investigation with production database:
1. ✅ Database contains 254 books across 69 series
2. ✅ Query logic works correctly (tested locally with prod DB)
3. ✅ Previous empty string filter fix was correct but insufficient
4. ❌ **Next.js was serving cached empty response from initial deployment**

The API was returning cached data from when the container first started (before Calibre sync ran), even though subsequent syncs populated the database with series data.

## Changes
- Add `export const dynamic = 'force-dynamic'` to `/api/series` route to disable Next.js route caching
- Add comprehensive debug logging to `seriesRepository.getAllSeries()`:
  - Log query start
  - Log book count found (INFO level)
  - Log series count returned (INFO level)
  - Log sample data for debugging (DEBUG level)

## Testing
- ✅ All existing tests pass (series repository + API tests)
- ✅ Verified query works with production database locally (returns 69 series)
- ✅ Lint checks pass

## Impact
- Ensures API always returns fresh data after Calibre syncs
- Provides visibility into query execution for troubleshooting
- Solves the "series entries on book logs but not series page" issue

## Deployment Notes
After deploying this fix, the series list page should immediately start working. The debug logs will help confirm the fix in production logs.