### PR TITLE
Add floating scroll-to-top button to library and series pages

### DIFF
--- a/app/library/page.tsx
+++ b/app/library/page.tsx
@@ -7,6 +7,7 @@ import { libraryService } from "@/lib/library-service";
 import { LibraryHeader } from "@/components/LibraryHeader";
 import { LibraryFilters } from "@/components/LibraryFilters";
 import { BookGrid } from "@/components/BookGrid";
+import { ScrollToTopButton } from "@/components/ScrollToTopButton";
 import { toast } from "@/utils/toast";
 
 function LibraryPageContent() {
@@ -271,6 +272,9 @@ function LibraryPageContent() {
 
       {/* Infinite scroll trigger */}
       <div ref={observerTarget} className="py-8" />
+
+      {/* Scroll to top button */}
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/app/series/page.tsx
+++ b/app/series/page.tsx
@@ -5,6 +5,7 @@ import { Library, BookMarked, Search, X } from "lucide-react";
 import SeriesCard from "@/components/SeriesCard";
 import SeriesCardSkeleton from "@/components/SeriesCardSkeleton";
 import { PageHeader } from "@/components/PageHeader";
+import { ScrollToTopButton } from "@/components/ScrollToTopButton";
 
 interface SeriesInfo {
   name: string;
@@ -166,6 +167,9 @@ export default function SeriesPage() {
           ))}
         </div>
       )}
+
+      {/* Scroll to top button */}
+      <ScrollToTopButton />
     </>
   );
 }

--- a/components/ScrollToTopButton.tsx
+++ b/components/ScrollToTopButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { ChevronUp } from 'lucide-react';
+
+export function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-32 md:bottom-6 right-4 z-40 w-14 h-14 rounded-full bg-[var(--accent)] text-white shadow-lg flex items-center justify-center hover:scale-110 transition-transform"
+      aria-label="Scroll to top"
+    >
+      <ChevronUp className="w-6 h-6" />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a floating action button that allows users to quickly scroll back to the top of library and series pages. Follows the same design pattern as the archive button on the journal page for visual consistency.

## Features

- ✅ Appears after scrolling 300px down, auto-hides when near top
- ✅ Smooth scroll animation for better UX
- ✅ Circular FAB design (56x56px) with accent color and shadow
- ✅ Hover scale effect (110%) for visual feedback
- ✅ Fully accessible (keyboard navigation + screen reader support)
- ✅ Responsive positioning (adjusts for mobile bottom nav)
- ✅ Visible on all screen sizes

## Implementation

Created a reusable `ScrollToTopButton` component:
- Tracks scroll position with event listener
- Shows/hides based on 300px threshold
- Uses `ChevronUp` icon from lucide-react
- Positioned at `bottom-32` (mobile) / `bottom-6` (tablet+), `right-4`
- Consistent z-index (z-40) with other floating elements

Added to:
- Library page (helps with infinite scroll)
- Series page (helps with long series lists)

## Test Plan

- [x] Button appears after scrolling 300px down
- [x] Button hides when scrolled back to top
- [x] Smooth scroll animation works correctly
- [x] Positioning doesn't overlap bottom navigation on mobile
- [x] Hover effect works as expected
- [x] Accessible via keyboard
- [x] All screen sizes display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)