### PR TITLE
Fix library filter input height inconsistencies

### DIFF
--- a/components/LibraryFilters.tsx
+++ b/components/LibraryFilters.tsx
@@ -367,10 +367,10 @@ export function LibraryFilters({
               type="button"
               onClick={() => setShowStatusDropdown(!showStatusDropdown)}
               disabled={loading}
-              className={`w-full px-3 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-md text-[var(--foreground)] hover:border-[var(--accent)] transition-colors flex items-center gap-2 disabled:opacity-50 h-[42px]`}
+              className={`w-full px-3 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-md text-[var(--foreground)] hover:border-[var(--accent)] transition-colors flex items-center gap-2 disabled:opacity-50 min-h-[42px]`}
             >
               <LibraryIcon className="w-4 h-4 shrink-0" />
-              <span className="flex-1 truncate text-left leading-none">
+              <span className="flex-1 truncate text-left text-sm">
                 {statusOptions.find(option => option.value === statusFilter)?.label || "All Books"}
               </span>
               <ChevronDown
@@ -429,10 +429,10 @@ export function LibraryFilters({
               type="button"
               onClick={() => setShowRatingDropdown(!showRatingDropdown)}
               disabled={loading}
-              className={`w-full px-3 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-md text-[var(--foreground)] hover:border-[var(--accent)] transition-colors flex items-center disabled:opacity-50 h-[42px]`}
+              className={`w-full px-3 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-md text-[var(--foreground)] hover:border-[var(--accent)] transition-colors flex items-center gap-2 disabled:opacity-50 min-h-[42px]`}
             >
-              <Star className="w-4 h-4 shrink-0 mr-2" />
-              <div className="flex-1 min-w-0 overflow-hidden flex items-center leading-none">
+              <Star className="w-4 h-4 shrink-0" />
+              <div className="flex-1 min-w-0 overflow-hidden flex items-center text-sm h-[20px]">
                 {(() => {
                   const selected = ratingOptions.find(option => option.value === ratingFilter);
                   if (selected?.stars) {
@@ -443,7 +443,7 @@ export function LibraryFilters({
               </div>
               <ChevronDown
                 className={cn(
-                  "w-4 h-4 transition-transform shrink-0 ml-2",
+                  "w-4 h-4 transition-transform shrink-0",
                   showRatingDropdown && "rotate-180"
                 )}
               />


### PR DESCRIPTION
## Summary

- Fixed input height inconsistencies between status and rating filter dropdowns on the library page
- Resolved issue where star-based ratings caused the rating dropdown to appear shorter than the status dropdown

## Changes

- Changed both filter dropdowns from fixed `h-[42px]` to `min-h-[42px]` to allow natural padding-based heights
- Added `h-[20px]` to the rating dropdown's content container to prevent star icons from collapsing the height
- Updated text styling from `leading-none` to `text-sm` for consistent sizing
- Standardized spacing using `gap-2` instead of individual margins for uniform appearance

## Testing

All inputs now maintain consistent heights regardless of content (text labels vs. star icons).