### PR TITLE
fix: resolve 'Object object' error when editing reading goals

### DIFF
--- a/components/ReadingGoalForm.tsx
+++ b/components/ReadingGoalForm.tsx
@@ -72,9 +72,9 @@ export function ReadingGoalForm({
     setSaving(true);
     try {
       if (mode === "create") {
-        await createGoalAsync({ year, targetBooks: booksGoal });
+        await createGoalAsync({ year, booksGoal });
       } else if (existingGoal) {
-        await updateGoalAsync({ id: existingGoal.id, data: { targetBooks: booksGoal } });
+        await updateGoalAsync({ id: existingGoal.id, data: { booksGoal } });
       }
       onSuccess();
     } catch (error) {

--- a/hooks/useReadingGoals.ts
+++ b/hooks/useReadingGoals.ts
@@ -4,11 +4,11 @@ import type { ReadingGoal } from "@/lib/db/schema";
 
 interface CreateGoalPayload {
   year: number;
-  targetBooks: number;
+  booksGoal: number;
 }
 
 interface UpdateGoalPayload {
-  targetBooks: number;
+  booksGoal: number;
 }
 
 /**
@@ -44,7 +44,10 @@ export function useReadingGoals() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to create reading goal');
+        const errorMessage = typeof errorData.error === 'object' 
+          ? errorData.error.message 
+          : errorData.error || 'Failed to create reading goal';
+        throw new Error(errorMessage);
       }
 
       return response.json();
@@ -69,7 +72,10 @@ export function useReadingGoals() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to update reading goal');
+        const errorMessage = typeof errorData.error === 'object' 
+          ? errorData.error.message 
+          : errorData.error || 'Failed to update reading goal';
+        throw new Error(errorMessage);
       }
 
       return response.json();
@@ -92,7 +98,10 @@ export function useReadingGoals() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to delete reading goal');
+        const errorMessage = typeof errorData.error === 'object' 
+          ? errorData.error.message 
+          : errorData.error || 'Failed to delete reading goal';
+        throw new Error(errorMessage);
       }
 
       return response.json();


### PR DESCRIPTION
## Summary
- Fixes the "[object Object]" error message displayed when editing reading goals
- Corrects API field name mismatch that was preventing goal updates from succeeding

## Changes
1. **Error Message Handling**: Updated `useReadingGoals` hook to properly extract error messages from API error objects. The API returns `{ error: { code: "...", message: "..." }}` but the hook was trying to use the error object directly as a string, resulting in "[object Object]" being displayed.

2. **API Field Name Fix**: Corrected mismatch where the client was sending `targetBooks` but the API expected `booksGoal` for both create and update operations.

## Testing
- ✅ All 1530 tests pass
- ✅ 41 reading goals integration tests pass