### PR TITLE
fix: remove test job dependency on auto-tag to fix tag-triggered builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,11 +64,6 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    # Skip tests if we just created a tag (they'll run again when the tag triggers the workflow)
-    if: |
-      always() && 
-      (needs.auto-tag.outputs.tag_created != 'true' || github.event_name == 'workflow_dispatch')
-    needs: [auto-tag]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

This PR fixes the workflow so that Docker builds and GitHub releases actually run when tags are pushed.

## The Problem

The test job had , which created a dependency chain. When running the workflow on a tag:
1.  job is skipped (it only runs on main branch pushes)
2.  job depends on , so even though it has conditions to run, GitHub Actions skips downstream jobs when dependencies are skipped
3.  depends on , so it also gets skipped
4. Result: No Docker image built, no release created

## The Solution

Remove the  dependency from the test job. Now:
-  runs independently (no dependencies)
-  depends only on 
-  depends on  and only runs for tags

## Testing

After merging this, we can recreate the v0.3.0 tag and the workflow will properly build and publish the Docker image.