### PR TITLE
fix: ensure FinishBookModal dismisses after confirming read status

### DIFF
--- a/__tests__/components/FinishBookModal.test.tsx
+++ b/__tests__/components/FinishBookModal.test.tsx
@@ -144,7 +144,7 @@ describe("FinishBookModal", () => {
     test("should clear draft after successful submit", async () => {
       // Arrange: Type a review (creates draft)
       localStorage.setItem("draft-finish-review-123", "My review");
-      const onConfirm = mock(() => {});
+      const onConfirm = mock(async () => {});
 
       render(<FinishBookModal {...defaultProps} onConfirm={onConfirm} />);
       const stars = screen.getAllByTestId("star-icon");
@@ -153,9 +153,13 @@ describe("FinishBookModal", () => {
       fireEvent.click(stars[3]); // 4 stars
       fireEvent.click(screen.getByText("Mark as Read"));
 
+      // Wait for async operations to complete
+      await waitFor(() => {
+        expect(onConfirm).toHaveBeenCalledWith(4, "My review");
+      });
+
       // Assert: Draft should be cleared
       expect(localStorage.getItem("draft-finish-review-123")).toBeNull();
-      expect(onConfirm).toHaveBeenCalledWith(4, "My review");
     });
 
     test("should preserve draft when modal is closed without submitting", () => {

--- a/components/FinishBookModal.tsx
+++ b/components/FinishBookModal.tsx
@@ -67,9 +67,10 @@ export default function FinishBookModal({
     logger.debug({ isOpen, bookId }, 'FinishBookModal state changed');
   }, [isOpen, bookId]);
 
-  const handleSubmit = () => {
-    onConfirm(rating, review || undefined);
+  const handleSubmit = async () => {
+    await onConfirm(rating, review || undefined);
     clearDraft(); // Clear draft after successful submission
+    onClose(); // Explicitly close the modal after successful confirmation
   };
 
   const handleClose = () => {


### PR DESCRIPTION
## Summary

- Fix modal dismissal bug where FinishBookModal wouldn't close on book detail page after clicking "Mark as Read"
- Ensure consistent modal behavior across dashboard and book detail page contexts

## Problem

The FinishBookModal was not dismissing on the book detail page (`/books/:id`) when clicking "Mark as Read", while it worked correctly on the dashboard. This created an inconsistent UX where users had to manually close the modal after marking a book as read.

## Root Cause

The `handleSubmit` function in `FinishBookModal.tsx` called `onConfirm()` but did not call `onClose()`, relying entirely on the parent component to update the `isOpen` prop. This worked in some contexts (like `LogProgressModal`) where the parent explicitly closed both modals, but failed in the book detail page context where the modal state update had timing issues with async mutations.

## Solution

Modified `FinishBookModal.handleSubmit` to:
1. Make the function async to properly await `onConfirm()` completion
2. Explicitly call `onClose()` after successful confirmation
3. This ensures consistent dismissal behavior across all usage contexts

## Changes

**`components/FinishBookModal.tsx`:**
- Made `handleSubmit` async
- Added explicit `onClose()` call after `onConfirm()` completes

**`__tests__/components/FinishBookModal.test.tsx`:**
- Updated test to handle async behavior with `waitFor()`
- Made mock `onConfirm` async to match real implementation

## Testing

- ✅ All 26 FinishBookModal tests passing
- ✅ Linter passes with no errors
- ✅ Test coverage maintained at 100% for FinishBookModal

## Verification

To test the fix:
1. Navigate to a book detail page with a book in "reading" status
2. Change the status dropdown to "Read"
3. Fill in rating/review in the FinishBookModal
4. Click "Mark as Read"
5. ✅ Modal should now dismiss automatically

## Related Issues

Fixes user-reported bug where modal wouldn't dismiss on book detail page.