### PR TITLE
Fix goals page to default to most recent year with goal

### DIFF
--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -7,8 +7,9 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0; // Disable all caching including router cache
 
 export default async function GoalsPage() {
-  // Get current year's reading goal
-  const currentGoal = await readingGoalsService.getCurrentYearGoal(null);
+  // Get the most appropriate goal for initial display (most recent year with a goal)
+  // Falls back to null if no goals exist (triggers onboarding)
+  const defaultGoal = await readingGoalsService.getDefaultGoal(null);
   
   // Get all goals for year selector
   const allGoals = await readingGoalsService.getAllGoals(null);
@@ -27,7 +28,7 @@ export default async function GoalsPage() {
       )}
 
       <GoalsPagePanel 
-        initialGoalData={currentGoal}
+        initialGoalData={defaultGoal}
         allGoals={allGoals}
       />
     </div>

--- a/lib/services/reading-goals.service.ts
+++ b/lib/services/reading-goals.service.ts
@@ -51,6 +51,28 @@ export class ReadingGoalsService {
   }
 
   /**
+   * Get the most appropriate goal for initial display
+   * Returns the most recent year's goal, or current year if no goals exist
+   * This ensures users see relevant data when landing on the goals page
+   */
+  async getDefaultGoal(userId: number | null): Promise<ReadingGoalWithProgress | null> {
+    const allGoals = await this.getAllGoals(userId);
+    
+    // If no goals exist, return null (triggers onboarding)
+    if (allGoals.length === 0) {
+      return null;
+    }
+
+    // Goals are already sorted by year descending from the repository
+    // Get the most recent goal (first in the list)
+    const mostRecentGoal = allGoals[0];
+    
+    // Get progress for this goal
+    const progress = await this.calculateProgress(userId, mostRecentGoal.year, mostRecentGoal.booksGoal);
+    return { goal: mostRecentGoal, progress };
+  }
+
+  /**
    * Get all goals for a user
    */
   async getAllGoals(userId: number | null): Promise<ReadingGoal[]> {


### PR DESCRIPTION
## Summary
Fixes issue where users cannot see their previous year's stats (e.g., 2025) on the /goals page because it defaults to the current year (2026) when no goal exists for the current year.

## Problem
- Users with a 2025 goal but no 2026 goal were seeing an empty state on initial page load
- The page was always fetching the current year's goal, even when it didn't exist
- Users had to manually select 2025 from the dropdown to see their stats

## Solution
- Added `getDefaultGoal()` method to `ReadingGoalsService` that intelligently selects the most recent year with a goal
- Updated `/goals` page to use this new method instead of always fetching current year
- Maintains existing onboarding flow when no goals exist

## Changes
- `lib/services/reading-goals.service.ts`: New method that returns most recent goal
- `app/goals/page.tsx`: Uses `getDefaultGoal()` instead of `getCurrentYearGoal()`

## Behavior
- **Before:** Always showed current year (2026), empty if no goal exists
- **After:** Shows most recent year with a goal (e.g., 2025), providing immediate access to relevant stats