### PR TITLE
fix: remove logger from middleware to prevent Edge Runtime errors

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { middlewareAuthCheck } from "@/lib/auth";
-import { withRequestContext, getLogger } from "@/lib/logger";
  
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -16,16 +15,11 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  return withRequestContext(() => {
-    const authResult = middlewareAuthCheck(request);
-    const logger = getLogger();
-    if (authResult) {
-      logger.debug({ path: request.nextUrl.pathname }, "Auth middleware intercepted request");
-      return authResult;
-    }
-    logger.debug({ path: request.nextUrl.pathname }, "Auth middleware passed request");
-    return NextResponse.next();
-  }, request.headers.get('x-request-id') || undefined);
+  const authResult = middlewareAuthCheck(request);
+  if (authResult) {
+    return authResult;
+  }
+  return NextResponse.next();
 }
  
 export const config = {


### PR DESCRIPTION
## Summary

- Remove Pino logger from middleware to resolve production 500 errors when `LOG_DEST` environment variable is set
- Simplify middleware to focus solely on authentication logic

## Problem

When `LOG_DEST` is set to a file path in production, the application returns 500 errors with the following:

```
TypeError: e$().destination is not a function
```

This occurs because:
1. Pino's `destination()` function requires Node.js filesystem APIs
2. Next.js middleware runs in the Edge Runtime by default (even in Next.js 16)
3. Edge Runtime does not support Node.js `fs` module operations
4. The logger module attempts to create file destinations at module load time, causing the bundle to fail

## Solution

Remove logger from middleware entirely because:
- Middleware only had 2 debug-level log statements
- Authentication flow can be observed through HTTP status codes and container logs
- Middleware should be lightweight (Next.js best practice)
- API routes and server components still have full logging with file destination support

## Future Work

During the Next.js 16 migration, we can:
- Migrate from `middleware.ts` to `proxy.ts` (new convention)
- Optionally configure Node.js runtime for proxy if logging is truly needed
- Evaluate if proxy logging provides enough value to justify the performance trade-off

## Testing

- [x] Removed logger imports and calls from middleware.ts
- [x] Verified middleware logic remains intact
- [x] Confirmed change only affects middleware (API routes retain full logging)

## Files Changed

- `middleware.ts`: Removed logger import and debug calls, simplified auth flow