### PR TITLE
Fix: Prevent book detail page from getting stuck in loading state after tag operations

### DIFF
--- a/app/books/[id]/page.tsx
+++ b/app/books/[id]/page.tsx
@@ -166,6 +166,9 @@ export default function BookDetailPage() {
       return response.json();
     },
     staleTime: 60000, // Cache for 1 minute
+    gcTime: 300000, // 5 minutes - match other queries
+    refetchOnMount: false, // Don't refetch when mounting if data exists
+    retry: 1, // Reduce retry attempts to prevent blocking
   });
   const availableTags = availableTagsData?.tags || [];
 


### PR DESCRIPTION
## Summary

- Fixes book detail page getting stuck in loading state after performing tag operations (merge/delete) on the tags page
- Makes the `availableTags` query less aggressive to prevent race conditions during cache invalidations

## Root Cause

After multiple tag operations on the tags page, the `availableTags` query cache gets invalidated repeatedly. When navigating to a book detail page immediately after, the aggressive refetching behavior of the `availableTags` query would cause the page to get stuck in a loading state due to a race condition.

## Changes

Modified `app/books/[id]/page.tsx` to configure the `availableTags` query with less aggressive caching behavior:

- **`refetchOnMount: false`** - Prevents unnecessary refetches when the component mounts if cached data already exists
- **`gcTime: 300000`** - Sets garbage collection time to 5 minutes to match other query configurations
- **`retry: 1`** - Reduces retry attempts from default (3) to 1, preventing the query from blocking page load

## Testing

This issue only reproduces in production (not in development) due to:
- Different caching behavior in production builds
- Real network latency vs localhost speeds
- React Strict Mode differences

To test in production:
1. Perform multiple tag operations (merge/delete) in quick succession on the tags page
2. Immediately navigate to a book detail page
3. Verify the page loads normally without getting stuck

## Impact

- Low risk: Changes are conservative and backward compatible
- Improves user experience by preventing stuck loading states
- Aligns `availableTags` query behavior with other queries in the codebase