### PR TITLE
Fix: Add journal page to cache invalidation

### DIFF
--- a/lib/services/progress.service.ts
+++ b/lib/services/progress.service.ts
@@ -481,6 +481,7 @@ export class ProgressService {
       revalidatePath("/"); // Dashboard
       revalidatePath("/library"); // Library page
       revalidatePath("/stats"); // Stats page
+      revalidatePath("/journal"); // Journal page
       revalidatePath(`/books/${bookId}`); // Book detail page
     } catch (error) {
             const { getLogger } = require("@/lib/logger");

--- a/lib/services/session.service.ts
+++ b/lib/services/session.service.ts
@@ -993,6 +993,7 @@ export class SessionService {
       revalidatePath("/"); // Dashboard
       revalidatePath("/library"); // Library page
       revalidatePath("/stats"); // Stats page
+      revalidatePath("/journal"); // Journal page
       revalidatePath(`/books/${bookId}`); // Book detail page
     } catch (error) {
       const { getLogger } = require("@/lib/logger");


### PR DESCRIPTION
## Summary
- Fixes journal page not updating after logging progress or editing session dates
- Adds `/journal` to cache invalidation in ProgressService and SessionService

## Problem
When logging progress on a book or updating session dates/reviews, the `/journal` page was not being revalidated, causing stale data to persist. Users had to manually refresh the page to see newly logged progress entries.

## Solution
Added `revalidatePath("/journal")` to the `invalidateCache()` methods in both:
- `lib/services/progress.service.ts` - Invalidates when creating, updating, or deleting progress entries
- `lib/services/session.service.ts` - Invalidates when updating session dates or reviews

## Testing
- Verified all cache invalidation call sites across the codebase
- Confirmed no other pages need journal invalidation (tags, ratings don't affect journal entries)

## Impact
The journal page will now immediately reflect changes when users:
- Log reading progress
- Edit or delete progress entries  
- Update session start/completion dates
- Add or edit session reviews