### PR TITLE
Fix modal scrim not spanning entire screen

### DIFF
--- a/components/BaseModal.tsx
+++ b/components/BaseModal.tsx
@@ -3,6 +3,7 @@
 import { X } from "lucide-react";
 import { cn } from "@/utils/cn";
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { Spinner } from "@/components/ui/Spinner";
 
 interface BaseModalProps {
@@ -37,6 +38,12 @@ export default function BaseModal({
   allowBackdropClose = true,
 }: BaseModalProps) {
   const [isAnimating, setIsAnimating] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
@@ -49,12 +56,12 @@ export default function BaseModal({
     }
   }, [isOpen]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !mounted) return null;
 
-  return (
+  const modalContent = (
     <div 
       className={cn(
-        "fixed inset-0 bg-black flex items-center justify-center z-50 p-4 transition-opacity duration-200",
+        "fixed top-0 left-0 right-0 bottom-0 bg-black flex items-center justify-center z-50 p-4 transition-opacity duration-200",
         isAnimating ? "bg-opacity-50" : "bg-opacity-0"
       )}
       onClick={allowBackdropClose ? onClose : undefined}
@@ -107,4 +114,6 @@ export default function BaseModal({
       </div>
     </div>
   );
+
+  return createPortal(modalContent, document.body);
 }


### PR DESCRIPTION
## Summary
- Fix modal backdrop (scrim) not spanning entire screen by using React portals
- Ensures all modals (including StreakEditModal) have properly positioned overlays

## Changes
- Updated BaseModal component to use `createPortal` to render directly to `document.body`
- Added mounted state check to prevent SSR hydration issues with portals
- This fix applies to all modals in the application that use BaseModal

Resolves #219