### PR TITLE
Add Check All/Uncheck All button for filtered tags

### DIFF
--- a/components/TagManagement/TagList.tsx
+++ b/components/TagManagement/TagList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect, useImperativeHandle, forwardRef } from "react";
-import { Search, CheckSquare, ChevronDown, Check, ArrowDownAZ, ArrowUpAZ, TrendingUp, TrendingDown, X } from "lucide-react";
+import { Search, CheckSquare, ChevronDown, Check, ArrowDownAZ, ArrowUpAZ, TrendingUp, TrendingDown, X, CheckCheck } from "lucide-react";
 import { TagItem, type TagWithStats } from "./TagItem";
 import { TagListSkeleton } from "./TagListSkeleton";
 import { cn } from "@/utils/cn";
@@ -157,6 +157,36 @@ export const TagList = forwardRef<TagListRef, TagListProps>(function TagList({
     setCheckedTags(new Set());
   };
 
+  // Check if all filtered tags are currently checked
+  const allFilteredChecked = useMemo(() => {
+    if (filteredAndSortedTags.length === 0) return false;
+    return filteredAndSortedTags.every(tag => checkedTags.has(tag.name));
+  }, [filteredAndSortedTags, checkedTags]);
+
+  // Handle check all / uncheck all toggle
+  const handleToggleAllFiltered = () => {
+    const newChecked = new Set(checkedTags);
+    
+    if (allFilteredChecked) {
+      // Uncheck all filtered tags
+      filteredAndSortedTags.forEach(tag => {
+        newChecked.delete(tag.name);
+      });
+    } else {
+      // Add all filtered tags to selection
+      filteredAndSortedTags.forEach(tag => {
+        newChecked.add(tag.name);
+      });
+    }
+    
+    setCheckedTags(newChecked);
+    
+    // Auto-enter checkbox mode if not already in it
+    if (!checkboxMode) {
+      setCheckboxMode(true);
+    }
+  };
+
   // Show loading skeleton if loading
   if (loading) {
     return <TagListSkeleton />;
@@ -249,13 +279,36 @@ export const TagList = forwardRef<TagListRef, TagListProps>(function TagList({
 
           {/* Bulk operations toggle */}
           {!checkboxMode ? (
-            <button
-              onClick={() => setCheckboxMode(true)}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-lg text-[var(--heading-text)] hover:border-[var(--accent)] hover:bg-[var(--foreground)]/5 transition-colors font-medium"
-            >
-              <CheckSquare className="w-4 h-4" />
-              Select Multiple
-            </button>
+            searchQuery.trim() ? (
+              // Show split buttons when actively filtering
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setCheckboxMode(true)}
+                  className="flex-[2] flex items-center justify-center gap-2 px-4 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-lg text-[var(--heading-text)] hover:border-[var(--accent)] hover:bg-[var(--foreground)]/5 transition-colors font-medium"
+                >
+                  <CheckSquare className="w-4 h-4" />
+                  Select Multiple
+                </button>
+                <button
+                  onClick={handleToggleAllFiltered}
+                  className="flex-1 flex items-center justify-center gap-1.5 px-3 py-2 bg-[var(--accent)] text-white border border-[var(--accent)] rounded-lg hover:bg-[var(--light-accent)] hover:border-[var(--light-accent)] transition-colors font-medium"
+                  title={allFilteredChecked ? "Uncheck all filtered tags" : "Check all filtered tags"}
+                >
+                  <CheckCheck className="w-4 h-4" />
+                  <span className="hidden sm:inline">{allFilteredChecked ? "Uncheck" : "Check"} All</span>
+                  <span className="sm:hidden">All</span>
+                </button>
+              </div>
+            ) : (
+              // Show single button when not filtering
+              <button
+                onClick={() => setCheckboxMode(true)}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-[var(--background)] border border-[var(--border-color)] rounded-lg text-[var(--heading-text)] hover:border-[var(--accent)] hover:bg-[var(--foreground)]/5 transition-colors font-medium"
+              >
+                <CheckSquare className="w-4 h-4" />
+                Select Multiple
+              </button>
+            )
           ) : (
             <div className="space-y-2">
               <div className="flex items-center justify-between text-sm text-[var(--subheading-text)]">


### PR DESCRIPTION
## Summary

- Adds a "Check All" / "Uncheck All" button when filtering tags via search query
- Button layout splits 2/3 "Select Multiple" and 1/3 "Check All" when actively filtering
- Check All button adds remaining filtered tags to existing selections (allows building selections across queries)
- Button text dynamically toggles between "Check All" and "Uncheck All" based on current state
- Auto-enters checkbox mode when Check All is clicked
- Responsive design: shows "All" on small screens, full text on larger screens

## Changes

- Updated `TagList` component to conditionally render split buttons when search query is active
- Added `allFilteredChecked` computed value to track if all filtered tags are currently selected
- Added `handleToggleAllFiltered` function to toggle all filtered tags on/off
- Import `CheckCheck` icon from lucide-react for the new button
- Maintains existing functionality when not filtering (single "Select Multiple" button)

## Testing

- Manually tested filtering + check all functionality
- Tested responsive behavior on different screen sizes
- Verified selection building across multiple queries
- Confirmed auto-enter checkbox mode behavior