### PR TITLE
Fix pino module loading error during instrumentation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
   // Turbopack configuration (empty for now, may need future migration)
   turbopack: {},
   // Externalize native modules for server-side rendering
-  serverExternalPackages: ['better-sqlite3', 'bun:sqlite'],
+  serverExternalPackages: ['better-sqlite3', 'bun:sqlite', 'pino', 'pino-pretty'],
   webpack: (config, { isServer, dev }) => {
     if (isServer) {
       // Additional webpack externals configuration for Next.js 16
@@ -34,7 +34,7 @@ const nextConfig: NextConfig = {
       
       // Add our native modules to externals
       externals.push(({ request }: any, callback: any) => {
-        if (request === 'better-sqlite3' || request === 'bun:sqlite') {
+        if (request === 'better-sqlite3' || request === 'bun:sqlite' || request === 'pino' || request === 'pino-pretty') {
           return callback(null, `commonjs ${request}`);
         }
         callback();


### PR DESCRIPTION
## Summary

Fixes production error where Next.js fails to load the pino logger module during the instrumentation phase with error: `EISDIR reading "/app/.next/node_modules/pino-28069d5257187539"`

## Changes

- **lib/logger.ts**: Changed pino initialization to lazy-load at runtime instead of at module import time
- **next.config.ts**: Added pino and pino-pretty to serverExternalPackages and webpack externals to prevent bundling

## Technical Details

Next.js 16 with Turbopack has issues bundling certain Node.js packages during the instrumentation phase. This fix:
1. Uses `require('pino')` inside a lazy initialization function instead of top-level import
2. Marks pino packages as external so they're not bundled by Next.js/Turbopack
3. Maintains full logging functionality - logger initializes on first use

## Testing

- Build completes successfully without pino module errors
- Logging functionality preserved at runtime