### PR TITLE
Add version display to settings page with update notifications

### DIFF
--- a/__tests__/api/version.test.ts
+++ b/__tests__/api/version.test.ts
@@ -1,0 +1,363 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from "@/app/api/version/route";
+import packageJson from "@/package.json";
+
+/**
+ * Version API Tests
+ * Tests the /api/version endpoint that provides current version and checks for updates
+ *
+ * Covers:
+ * - Returns current version from package.json
+ * - Fetches and parses GitHub release data
+ * - Correctly identifies minor and major version updates
+ * - Handles GitHub API failures gracefully
+ * - Skips draft and prerelease versions
+ * - Parses semantic version strings correctly
+ */
+
+describe("Version API - GET /api/version", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    // Mock fetch for GitHub API calls
+    global.fetch = vi.fn() as any;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  test("returns current version from package.json", async () => {
+    // Mock GitHub API to return no releases (404)
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.currentVersion).toBe(packageJson.version);
+  });
+
+  test("successfully fetches and compares with GitHub latest release", async () => {
+    const mockRelease = {
+      tag_name: "v0.5.0",
+      name: "Tome v0.5.0 - New Features",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.5.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.currentVersion).toBe(packageJson.version);
+    expect(data.latestVersion).toBe("v0.5.0");
+    expect(data.latestReleaseUrl).toBe(mockRelease.html_url);
+    expect(data.latestReleaseName).toBe(mockRelease.name);
+    expect(data.publishedAt).toBe(mockRelease.published_at);
+  });
+
+  test("identifies minor version update correctly (0.4.0 -> 0.5.0)", async () => {
+    const mockRelease = {
+      tag_name: "v0.5.0",
+      name: "Tome v0.5.0",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.5.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    // Assuming current version is 0.4.0, this should be detected as an update
+    expect(data.hasNewVersion).toBe(true);
+    expect(data.isMinorOrMajor).toBe(true);
+  });
+
+  test("does not notify for patch version updates (0.4.0 -> 0.4.1)", async () => {
+    const mockRelease = {
+      tag_name: "v0.4.1",
+      name: "Tome v0.4.1",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.4.1",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    // Patch updates should not trigger notification in pre-1.0
+    expect(data.hasNewVersion).toBe(false);
+    expect(data.isMinorOrMajor).toBe(false);
+  });
+
+  test("identifies major version update correctly (0.x.x -> 1.x.x)", async () => {
+    const mockRelease = {
+      tag_name: "v1.0.0",
+      name: "Tome v1.0.0 - Major Release",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v1.0.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.hasNewVersion).toBe(true);
+    expect(data.isMinorOrMajor).toBe(true);
+  });
+
+  test("does not notify when versions are the same", async () => {
+    const mockRelease = {
+      tag_name: `v${packageJson.version}`,
+      name: `Tome v${packageJson.version}`,
+      html_url: `https://github.com/masonfox/tome/releases/tag/v${packageJson.version}`,
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.hasNewVersion).toBe(false);
+    expect(data.isMinorOrMajor).toBe(false);
+  });
+
+  test("skips draft releases", async () => {
+    const mockRelease = {
+      tag_name: "v0.5.0",
+      name: "Tome v0.5.0 (Draft)",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.5.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: true,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.latestVersion).toBeNull();
+    expect(data.hasNewVersion).toBe(false);
+    expect(data.error).toBe("Unable to check for updates");
+  });
+
+  test("skips prerelease versions", async () => {
+    const mockRelease = {
+      tag_name: "v0.5.0-beta.1",
+      name: "Tome v0.5.0 Beta 1",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.5.0-beta.1",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: true,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.latestVersion).toBeNull();
+    expect(data.hasNewVersion).toBe(false);
+  });
+
+  test("handles GitHub API rate limit (403)", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.currentVersion).toBe(packageJson.version);
+    expect(data.latestVersion).toBeNull();
+    expect(data.hasNewVersion).toBe(false);
+    expect(data.error).toBe("Unable to check for updates");
+  });
+
+  test("handles GitHub API not found (404)", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.currentVersion).toBe(packageJson.version);
+    expect(data.latestVersion).toBeNull();
+    expect(data.error).toBe("Unable to check for updates");
+  });
+
+  test("handles network errors gracefully", async () => {
+    (global.fetch as any).mockRejectedValueOnce(new Error("Network error"));
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.currentVersion).toBe(packageJson.version);
+    expect(data.latestVersion).toBeNull();
+    expect(data.hasNewVersion).toBe(false);
+    expect(data.error).toBe("Unable to check for updates");
+    expect(response.status).toBe(200); // Should still return 200 with partial data
+  });
+
+  test("handles GitHub API server error (500)", async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.currentVersion).toBe(packageJson.version);
+    expect(data.latestVersion).toBeNull();
+    expect(data.error).toBe("Unable to check for updates");
+  });
+
+  test("handles malformed version strings gracefully", async () => {
+    const mockRelease = {
+      tag_name: "invalid-version",
+      name: "Bad Release",
+      html_url: "https://github.com/masonfox/tome/releases/tag/invalid",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    // Should not crash, just not detect an update
+    expect(data.currentVersion).toBe(packageJson.version);
+    expect(data.hasNewVersion).toBe(false);
+  });
+
+  test("parses version with 'v' prefix correctly", async () => {
+    const mockRelease = {
+      tag_name: "v0.5.0", // With 'v' prefix
+      name: "Tome v0.5.0",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.5.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.latestVersion).toBe("v0.5.0");
+    // Version comparison should still work with 'v' prefix
+  });
+
+  test("parses version without 'v' prefix correctly", async () => {
+    const mockRelease = {
+      tag_name: "0.5.0", // Without 'v' prefix
+      name: "Tome 0.5.0",
+      html_url: "https://github.com/masonfox/tome/releases/tag/0.5.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.latestVersion).toBe("0.5.0");
+  });
+
+  test("includes proper User-Agent header in GitHub request", async () => {
+    const mockRelease = {
+      tag_name: "v0.5.0",
+      name: "Tome v0.5.0",
+      html_url: "https://github.com/masonfox/tome/releases/tag/v0.5.0",
+      published_at: "2026-01-10T12:00:00Z",
+      prerelease: false,
+      draft: false,
+    };
+
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockRelease,
+    });
+
+    await GET();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/masonfox/tome/releases/latest',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': 'Tome-App',
+        }),
+      })
+    );
+  });
+});

--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -1,0 +1,200 @@
+import { getLogger } from "@/lib/logger";
+import { NextResponse } from "next/server";
+import packageJson from "@/package.json";
+
+/**
+ * Version API Route
+ * 
+ * Provides current application version and checks for new releases on GitHub.
+ * Caches GitHub API responses for 24 hours to respect rate limits (60/hour unauthenticated).
+ * 
+ * For pre-1.0 versions, notifies users of minor version updates (e.g., 0.4.0 → 0.5.0).
+ * Post-1.0, would typically only notify for major versions.
+ */
+
+interface VersionInfo {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+interface GitHubRelease {
+  tag_name: string;
+  name: string;
+  html_url: string;
+  published_at: string;
+  prerelease: boolean;
+  draft: boolean;
+}
+
+interface VersionResponse {
+  currentVersion: string;
+  latestVersion: string | null;
+  hasNewVersion: boolean;
+  isMinorOrMajor: boolean;
+  latestReleaseUrl: string | null;
+  latestReleaseName: string | null;
+  publishedAt: string | null;
+  error?: string;
+}
+
+/**
+ * Parse semantic version string into components
+ * Handles both "v0.4.0" and "0.4.0" formats
+ */
+function parseVersion(version: string): VersionInfo | null {
+  try {
+    // Remove 'v' prefix if present
+    const clean = version.replace(/^v/, '');
+    const parts = clean.split('.');
+    
+    if (parts.length !== 3) {
+      return null;
+    }
+    
+    const [major, minor, patch] = parts.map(Number);
+    
+    if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+      return null;
+    }
+    
+    return { major, minor, patch };
+  } catch (error) {
+    getLogger().error({ err: error, version }, "Failed to parse version");
+    return null;
+  }
+}
+
+/**
+ * Compare two versions to determine if an update is available
+ * For pre-1.0 versions, treats minor version changes as significant
+ */
+function compareVersions(current: string, latest: string): {
+  hasUpdate: boolean;
+  isMinorOrMajor: boolean;
+} {
+  const curr = parseVersion(current);
+  const lat = parseVersion(latest);
+  
+  if (!curr || !lat) {
+    return { hasUpdate: false, isMinorOrMajor: false };
+  }
+  
+  // Major version increase (e.g., 0.x.x → 1.x.x)
+  if (lat.major > curr.major) {
+    return { hasUpdate: true, isMinorOrMajor: true };
+  }
+  
+  // Minor version increase (e.g., 0.4.x → 0.5.x)
+  // Important for pre-1.0 development!
+  if (lat.major === curr.major && lat.minor > curr.minor) {
+    return { hasUpdate: true, isMinorOrMajor: true };
+  }
+  
+  // Patch version increase (e.g., 0.4.0 → 0.4.1)
+  // Don't notify for patch updates in pre-1.0
+  if (lat.major === curr.major && lat.minor === curr.minor && lat.patch > curr.patch) {
+    return { hasUpdate: false, isMinorOrMajor: false };
+  }
+  
+  return { hasUpdate: false, isMinorOrMajor: false };
+}
+
+/**
+ * Fetch latest release information from GitHub
+ * Cached for 24 hours to respect rate limits
+ */
+async function fetchLatestRelease(): Promise<GitHubRelease | null> {
+  try {
+    const response = await fetch(
+      'https://api.github.com/repos/masonfox/tome/releases/latest',
+      {
+        next: { revalidate: 86400 }, // 24 hours in seconds
+        headers: {
+          'Accept': 'application/vnd.github+json',
+          'User-Agent': 'Tome-App',
+        },
+      }
+    );
+    
+    if (!response.ok) {
+      if (response.status === 404) {
+        getLogger().warn("No releases found on GitHub");
+        return null;
+      }
+      if (response.status === 403) {
+        getLogger().warn("GitHub API rate limit exceeded");
+        return null;
+      }
+      throw new Error(`GitHub API returned ${response.status}`);
+    }
+    
+    const data: GitHubRelease = await response.json();
+    
+    // Skip draft and prerelease versions
+    if (data.draft || data.prerelease) {
+      return null;
+    }
+    
+    return data;
+  } catch (error) {
+    getLogger().error({ err: error }, "Failed to fetch latest release from GitHub");
+    return null;
+  }
+}
+
+export async function GET() {
+  try {
+    const currentVersion = packageJson.version;
+    
+    // Fetch latest release from GitHub
+    const latestRelease = await fetchLatestRelease();
+    
+    // If GitHub fetch failed, return current version only
+    if (!latestRelease) {
+      const response: VersionResponse = {
+        currentVersion,
+        latestVersion: null,
+        hasNewVersion: false,
+        isMinorOrMajor: false,
+        latestReleaseUrl: null,
+        latestReleaseName: null,
+        publishedAt: null,
+        error: "Unable to check for updates",
+      };
+      return NextResponse.json(response);
+    }
+    
+    // Compare versions
+    const latestVersion = latestRelease.tag_name;
+    const { hasUpdate, isMinorOrMajor } = compareVersions(currentVersion, latestVersion);
+    
+    const response: VersionResponse = {
+      currentVersion,
+      latestVersion,
+      hasNewVersion: hasUpdate && isMinorOrMajor,
+      isMinorOrMajor,
+      latestReleaseUrl: latestRelease.html_url,
+      latestReleaseName: latestRelease.name,
+      publishedAt: latestRelease.published_at,
+    };
+    
+    return NextResponse.json(response);
+  } catch (error) {
+    getLogger().error({ err: error }, "Error in version API");
+    
+    // Even on error, return current version
+    const response: VersionResponse = {
+      currentVersion: packageJson.version,
+      latestVersion: null,
+      hasNewVersion: false,
+      isMinorOrMajor: false,
+      latestReleaseUrl: null,
+      latestReleaseName: null,
+      publishedAt: null,
+      error: "Failed to check for updates",
+    };
+    
+    return NextResponse.json(response, { status: 200 });
+  }
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,6 +2,7 @@ import { Settings as SettingsIcon } from "lucide-react";
 import { ThemeSettings } from "@/components/ThemeSettings";
 import { TimezoneSettings } from "@/components/TimezoneSettings";
 import { PageHeader } from "@/components/PageHeader";
+import { VersionSettings } from "@/components/VersionSettings";
 import { streakService } from "@/lib/services/streak.service";
 
 export const dynamic = 'force-dynamic';
@@ -24,6 +25,9 @@ export default async function SettingsPage() {
 
       {/* Timezone Settings */}
       <TimezoneSettings initialTimezone={initialTimezone} />
+
+      {/* Version Information */}
+      <VersionSettings />
     </div>
   );
 }

--- a/components/VersionSettings.tsx
+++ b/components/VersionSettings.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useVersion } from "@/hooks/useVersion";
+import { PackageCheck, ExternalLink, AlertCircle, CheckCircle } from "lucide-react";
+import { format } from "date-fns";
+
+export function VersionSettings() {
+  const { data: versionData, isLoading, error } = useVersion();
+
+  return (
+    <div className="bg-[var(--card-bg)] border border-[var(--border-color)] rounded-md p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <PackageCheck className="w-6 h-6 text-[var(--accent)]" />
+        <h3 className="text-xl font-serif font-bold text-[var(--heading-text)]">
+          Version
+        </h3>
+      </div>
+
+      <p className="text-sm text-[var(--subheading-text)] mb-4 font-medium">
+        Information about this Tome installation
+      </p>
+
+      {/* Loading State */}
+      {isLoading && (
+        <div className="space-y-3">
+          <div className="h-4 bg-[var(--border-color)] rounded animate-pulse w-40" />
+          <div className="h-4 bg-[var(--border-color)] rounded animate-pulse w-32" />
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && !versionData && (
+        <div className="flex items-center gap-2 text-sm text-[var(--foreground)]/70">
+          <AlertCircle className="w-4 h-4" />
+          <span>Unable to fetch version information</span>
+        </div>
+      )}
+
+      {/* Success State */}
+      {versionData && (
+        <div className="space-y-4">
+          {/* Current Version */}
+          <div>
+            <span className="text-sm font-semibold text-[var(--foreground)]/70">
+              Current Version:
+            </span>{" "}
+            <span className="text-base font-bold text-[var(--foreground)]">
+              {versionData.currentVersion}
+            </span>
+          </div>
+
+          {/* Update Available Notification */}
+          {versionData.hasNewVersion && versionData.latestVersion && (
+            <div className="inline-block bg-[var(--background)] rounded-md p-4 pr-8 space-y-3">
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 w-5 h-5 bg-[var(--accent)] rounded-full flex items-center justify-center mt-0.5">
+                  <span className="text-white text-xs font-bold">!</span>
+                </div>
+                <div className="flex-1">
+                  <p className="font-semibold text-[var(--foreground)] mb-1">
+                    New version available!
+                  </p>
+                  <p className="text-sm text-[var(--subheading-text)]">
+                    Version <span className="font-bold">{versionData.latestVersion.replace(/^v/, '')}</span> is now available
+                    {versionData.publishedAt && (
+                      <span className="text-xs ml-1">
+                        (released {format(new Date(versionData.publishedAt), "MMM d, yyyy")})
+                      </span>
+                    )}
+                  </p>
+                  {versionData.latestReleaseName && (
+                    <p className="text-xs text-[var(--subheading-text)] mt-1 italic">
+                      {versionData.latestReleaseName}
+                    </p>
+                  )}
+                </div>
+              </div>
+
+              {/* View Release Button */}
+              {versionData.latestReleaseUrl && (
+                <div className="pl-8">
+                  <a
+                    href={versionData.latestReleaseUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--accent)] hover:bg-[var(--accent)]/90 text-white font-semibold rounded-sm transition-colors focus:outline-none focus:outline focus:outline-2 focus:outline-[var(--accent)] focus:outline-offset-2"
+                  >
+                    <span>View Release Notes</span>
+                    <ExternalLink className="w-4 h-4" />
+                  </a>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* No Update Available - Show Last Check Info */}
+          {!versionData.hasNewVersion && versionData.latestVersion && (
+            <div className="flex items-center gap-2 text-sm text-[var(--subheading-text)] font-medium">
+              <CheckCircle className="w-4 h-4 text-green-600" />
+              <span>You're running the latest version</span>
+            </div>
+          )}
+
+          {/* GitHub Check Failed */}
+          {versionData.error && (
+            <div className="flex items-center gap-2 text-xs text-[var(--foreground)]/50">
+              <AlertCircle className="w-3 h-3" />
+              <span>{versionData.error}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/useVersion.ts
+++ b/hooks/useVersion.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query";
+
+/**
+ * Version data returned from the API
+ */
+export interface VersionData {
+  currentVersion: string;
+  latestVersion: string | null;
+  hasNewVersion: boolean;
+  isMinorOrMajor: boolean;
+  latestReleaseUrl: string | null;
+  latestReleaseName: string | null;
+  publishedAt: string | null;
+  error?: string;
+}
+
+/**
+ * Custom hook for fetching version information
+ * 
+ * Checks current app version and latest release from GitHub.
+ * Data is cached for 24 hours to minimize API requests.
+ * 
+ * @returns Query result with version data, loading state, and error handling
+ */
+export function useVersion() {
+  return useQuery<VersionData>({
+    queryKey: ['version'],
+    queryFn: async () => {
+      const response = await fetch('/api/version');
+      if (!response.ok) {
+        throw new Error('Failed to fetch version information');
+      }
+      return response.json();
+    },
+    staleTime: 1000 * 60 * 60 * 24, // 24 hours - matches API cache
+    refetchOnWindowFocus: false, // Don't refetch when user returns to tab
+    retry: 1, // Only retry once on failure to avoid hammering the API
+  });
+}


### PR DESCRIPTION
## Summary

- Adds current Tome version display to `/settings` page
- Implements automatic checking for new releases from GitHub
- Notifies users when new minor/major versions are available (e.g., 0.4.0 → 0.5.0)
- Does not notify for patch updates (e.g., 0.4.0 → 0.4.1)

Closes #228

## Changes

### New Files
- **`app/api/version/route.ts`** - API endpoint that fetches current version from package.json and latest release from GitHub API with 24-hour caching
- **`hooks/useVersion.ts`** - React Query hook for fetching version data with proper caching
- **`components/VersionSettings.tsx`** - UI component displaying version info with update notifications
- **`__tests__/api/version.test.ts`** - Comprehensive tests (16 passing) covering version comparison, API integration, and error handling

### Modified Files
- **`app/settings/page.tsx`** - Added VersionSettings component to settings page

## Features

### Version Display
- Shows current version from package.json
- CheckCircle icon when running latest version
- Clean, minimal design consistent with other settings sections

### Update Notifications
- Checks GitHub releases API for latest version
- Notifies for minor/major version updates (pre-1.0 treats 0.x.0 → 0.y.0 as significant)
- Skips draft and prerelease versions
- Displays release name, date, and direct link to release notes
- Always visible when update available (no dismiss functionality)

### Performance & Reliability
- 24-hour cache on GitHub API requests to respect rate limits (60/hour unauthenticated)
- Graceful error handling - always shows current version even if GitHub check fails
- Proper semantic versioning comparison
- Handles malformed versions safely

## Testing

- ✅ All 16 API route tests passing
- ✅ Version comparison logic tested (minor, major, patch, same version)
- ✅ GitHub API error handling tested (rate limits, network failures, 404s)
- ✅ Draft/prerelease filtering tested

## Screenshots

Update notification panel with compact layout and differentiated background.