### PR TITLE
feat: add option to add books to top of shelf (#267)

### DIFF
--- a/__tests__/repositories/shelf-add-to-top.test.ts
+++ b/__tests__/repositories/shelf-add-to-top.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { shelfRepository } from "@/lib/repositories/shelf.repository";
+import { bookRepository } from "@/lib/repositories/book.repository";
+import { setupTestDatabase, teardownTestDatabase, clearTestDatabase } from "@/__tests__/helpers/db-setup";
+
+describe("ShelfRepository - Add to Top", () => {
+  beforeAll(async () => {
+    await setupTestDatabase(__filename);
+  });
+
+  beforeEach(async () => {
+    await clearTestDatabase(__filename);
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase(__filename);
+  });
+
+  describe("addBookToShelfAtTop", () => {
+    it("should add book to position 0 when shelf is empty", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Empty Shelf",
+        userId: null,
+      });
+
+      // Create a book
+      const book = await bookRepository.create({
+        calibreId: 1,
+        title: "First Book",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      // Add book to top of empty shelf
+      const result = await shelfRepository.addBookToShelfAtTop(shelf.id, book!.id);
+
+      // Should return the inserted record
+      expect(result).toBeDefined();
+      expect(result.shelfId).toBe(shelf.id);
+      expect(result.bookId).toBe(book!.id);
+      expect(result.sortOrder).toBe(0);
+
+      // Verify the book is on the shelf at position 0
+      const books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(1);
+      expect(books[0]?.id).toBe(book!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+    });
+
+    it("should shift existing books down when adding to top", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create three books
+      const book1 = await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      const book2 = await bookRepository.create({
+        calibreId: 2,
+        title: "Book 2",
+        authors: ["Author 2"],
+        tags: [],
+        path: "/path/2",
+      });
+
+      const book3 = await bookRepository.create({
+        calibreId: 3,
+        title: "Book 3",
+        authors: ["Author 3"],
+        tags: [],
+        path: "/path/3",
+      });
+
+      // Add books to end (positions 0, 1, 2)
+      await shelfRepository.addBookToShelf(shelf.id, book1!.id);
+      await shelfRepository.addBookToShelf(shelf.id, book2!.id);
+      await shelfRepository.addBookToShelf(shelf.id, book3!.id);
+
+      // Verify initial order
+      let books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(3);
+      expect(books[0]?.id).toBe(book1!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.id).toBe(book2!.id);
+      expect(books[1]?.sortOrder).toBe(1);
+      expect(books[2]?.id).toBe(book3!.id);
+      expect(books[2]?.sortOrder).toBe(2);
+
+      // Create a new book
+      const newBook = await bookRepository.create({
+        calibreId: 4,
+        title: "New Book",
+        authors: ["Author 4"],
+        tags: [],
+        path: "/path/4",
+      });
+
+      // Add new book to top
+      await shelfRepository.addBookToShelfAtTop(shelf.id, newBook!.id);
+
+      // Verify new order - newBook should be at 0, others shifted down
+      books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(4);
+      expect(books[0]?.id).toBe(newBook!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.id).toBe(book1!.id);
+      expect(books[1]?.sortOrder).toBe(1);
+      expect(books[2]?.id).toBe(book2!.id);
+      expect(books[2]?.sortOrder).toBe(2);
+      expect(books[3]?.id).toBe(book3!.id);
+      expect(books[3]?.sortOrder).toBe(3);
+    });
+
+    it("should maintain correct sortOrder after multiple top additions", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create five books
+      const books = [];
+      for (let i = 1; i <= 5; i++) {
+        const book = await bookRepository.create({
+          calibreId: i,
+          title: `Book ${i}`,
+          authors: [`Author ${i}`],
+          tags: [],
+          path: `/path/${i}`,
+        });
+        books.push(book);
+      }
+
+      // Add all books to top in sequence
+      // After all additions, order should be: book5, book4, book3, book2, book1
+      for (const book of books) {
+        await shelfRepository.addBookToShelfAtTop(shelf.id, book!.id);
+      }
+
+      // Verify final order (FIFO: first added ends up at bottom)
+      const shelfBooks = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(shelfBooks).toHaveLength(5);
+      
+      // Book 5 was added last, so it's at position 0
+      expect(shelfBooks[0]?.id).toBe(books[4]!.id);
+      expect(shelfBooks[0]?.sortOrder).toBe(0);
+      
+      // Book 4 was added second-to-last, so it's at position 1
+      expect(shelfBooks[1]?.id).toBe(books[3]!.id);
+      expect(shelfBooks[1]?.sortOrder).toBe(1);
+      
+      // Book 3 was added third-to-last, so it's at position 2
+      expect(shelfBooks[2]?.id).toBe(books[2]!.id);
+      expect(shelfBooks[2]?.sortOrder).toBe(2);
+      
+      // Book 2 was added second, so it's at position 3
+      expect(shelfBooks[3]?.id).toBe(books[1]!.id);
+      expect(shelfBooks[3]?.sortOrder).toBe(3);
+      
+      // Book 1 was added first, so it's at position 4
+      expect(shelfBooks[4]?.id).toBe(books[0]!.id);
+      expect(shelfBooks[4]?.sortOrder).toBe(4);
+    });
+
+    it("should handle adding to top of shelf with gaps in sortOrder", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Shelf with Gaps",
+        userId: null,
+      });
+
+      // Create three books
+      const book1 = await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      const book2 = await bookRepository.create({
+        calibreId: 2,
+        title: "Book 2",
+        authors: ["Author 2"],
+        tags: [],
+        path: "/path/2",
+      });
+
+      const book3 = await bookRepository.create({
+        calibreId: 3,
+        title: "Book 3",
+        authors: ["Author 3"],
+        tags: [],
+        path: "/path/3",
+      });
+
+      // Add books with specific sortOrder to create gaps (0, 5, 10)
+      await shelfRepository.addBookToShelf(shelf.id, book1!.id, 0);
+      await shelfRepository.addBookToShelf(shelf.id, book2!.id, 5);
+      await shelfRepository.addBookToShelf(shelf.id, book3!.id, 10);
+
+      // Verify initial order with gaps
+      let books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(3);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.sortOrder).toBe(5);
+      expect(books[2]?.sortOrder).toBe(10);
+
+      // Create a new book
+      const newBook = await bookRepository.create({
+        calibreId: 4,
+        title: "New Book",
+        authors: ["Author 4"],
+        tags: [],
+        path: "/path/4",
+      });
+
+      // Add new book to top
+      await shelfRepository.addBookToShelfAtTop(shelf.id, newBook!.id);
+
+      // Verify new order - all existing books shifted by 1
+      books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(4);
+      expect(books[0]?.id).toBe(newBook!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.id).toBe(book1!.id);
+      expect(books[1]?.sortOrder).toBe(1);
+      expect(books[2]?.id).toBe(book2!.id);
+      expect(books[2]?.sortOrder).toBe(6);
+      expect(books[3]?.id).toBe(book3!.id);
+      expect(books[3]?.sortOrder).toBe(11);
+    });
+
+    it("should handle large shelf efficiently", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Large Shelf",
+        userId: null,
+      });
+
+      // Add 100 books to the shelf
+      const books = [];
+      for (let i = 1; i <= 100; i++) {
+        const book = await bookRepository.create({
+          calibreId: i,
+          title: `Book ${i}`,
+          authors: [`Author ${i}`],
+          tags: [],
+          path: `/path/${i}`,
+        });
+        books.push(book);
+        await shelfRepository.addBookToShelf(shelf.id, book!.id);
+      }
+
+      // Verify initial count
+      let shelfBooks = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(shelfBooks).toHaveLength(100);
+
+      // Create a new book
+      const newBook = await bookRepository.create({
+        calibreId: 101,
+        title: "New Book",
+        authors: ["Author 101"],
+        tags: [],
+        path: "/path/101",
+      });
+
+      // Measure time for adding to top
+      const startTime = Date.now();
+      await shelfRepository.addBookToShelfAtTop(shelf.id, newBook!.id);
+      const endTime = Date.now();
+      const duration = endTime - startTime;
+
+      // Should complete in reasonable time (<500ms as per plan)
+      expect(duration).toBeLessThan(500);
+
+      // Verify new book is at position 0
+      shelfBooks = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(shelfBooks).toHaveLength(101);
+      expect(shelfBooks[0]?.id).toBe(newBook!.id);
+      expect(shelfBooks[0]?.sortOrder).toBe(0);
+
+      // Verify first original book shifted to position 1
+      expect(shelfBooks[1]?.id).toBe(books[0]!.id);
+      expect(shelfBooks[1]?.sortOrder).toBe(1);
+
+      // Verify last book is now at position 100
+      expect(shelfBooks[100]?.id).toBe(books[99]!.id);
+      expect(shelfBooks[100]?.sortOrder).toBe(100);
+    });
+
+    it("should work correctly with transaction isolation", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create two books
+      const book1 = await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      const book2 = await bookRepository.create({
+        calibreId: 2,
+        title: "Book 2",
+        authors: ["Author 2"],
+        tags: [],
+        path: "/path/2",
+      });
+
+      // Add book1 to shelf
+      await shelfRepository.addBookToShelf(shelf.id, book1!.id);
+
+      // Add book2 to top - should complete atomically
+      const result = await shelfRepository.addBookToShelfAtTop(shelf.id, book2!.id);
+
+      // Verify result
+      expect(result).toBeDefined();
+      expect(result.sortOrder).toBe(0);
+
+      // Verify both books are on shelf in correct order
+      const books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(2);
+      expect(books[0]?.id).toBe(book2!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.id).toBe(book1!.id);
+      expect(books[1]?.sortOrder).toBe(1);
+    });
+
+    it("should throw error if transaction fails", async () => {
+      // This test verifies that if anything goes wrong during the transaction,
+      // the entire operation is rolled back
+      
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create a book
+      const book = await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      // Add book to shelf
+      await shelfRepository.addBookToShelf(shelf.id, book!.id);
+
+      // Try to add the same book again to top (should fail due to unique constraint)
+      await expect(async () => {
+        await shelfRepository.addBookToShelfAtTop(shelf.id, book!.id);
+      }).rejects.toThrow();
+
+      // Verify original book is still at position 0 (no partial update)
+      const books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(1);
+      expect(books[0]?.id).toBe(book!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+    });
+  });
+});

--- a/__tests__/services/shelf-add-to-top.test.ts
+++ b/__tests__/services/shelf-add-to-top.test.ts
@@ -1,0 +1,267 @@
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDatabase, teardownTestDatabase, clearTestDatabase } from "@/__tests__/helpers/db-setup";
+import { shelfRepository } from "@/lib/repositories/shelf.repository";
+import { bookRepository } from "@/lib/repositories/book.repository";
+import { ShelfService } from "@/lib/services/shelf.service";
+
+describe("ShelfService - Add to Top", () => {
+  let shelfService: ShelfService;
+
+  beforeAll(async () => {
+    await setupTestDatabase(__filename);
+    shelfService = new ShelfService();
+  });
+
+  afterAll(async () => {
+    await teardownTestDatabase(__filename);
+  });
+
+  beforeEach(async () => {
+    await clearTestDatabase(__filename);
+  });
+
+  describe("addBookToShelfAtTop", () => {
+    test("should validate shelf exists", async () => {
+      // Create a book
+      const book = await bookRepository.create({
+        calibreId: 1,
+        title: "Test Book",
+        authors: ["Author"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      // Try to add to non-existent shelf
+      await expect(async () => {
+        await shelfService.addBookToShelfAtTop(999, book!.id);
+      }).rejects.toThrow("Shelf with ID 999 not found");
+    });
+
+    test("should validate book exists", async () => {
+      // Create a shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Try to add non-existent book
+      await expect(async () => {
+        await shelfService.addBookToShelfAtTop(shelf.id, 999);
+      }).rejects.toThrow("Book with ID 999 not found");
+    });
+
+    test("should prevent duplicate book-shelf associations", async () => {
+      // Create shelf and book
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      const book = await bookRepository.create({
+        calibreId: 1,
+        title: "Test Book",
+        authors: ["Author"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      // Add book to shelf normally
+      await shelfRepository.addBookToShelf(shelf.id, book!.id);
+
+      // Try to add same book to top
+      await expect(async () => {
+        await shelfService.addBookToShelfAtTop(shelf.id, book!.id);
+      }).rejects.toThrow(`Book is already on shelf "Test Shelf"`);
+    });
+
+    test("should successfully add book to top of shelf", async () => {
+      // Create shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create books
+      const book1 = await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      const book2 = await bookRepository.create({
+        calibreId: 2,
+        title: "Book 2",
+        authors: ["Author 2"],
+        tags: [],
+        path: "/path/2",
+      });
+
+      // Add book1 to shelf normally
+      await shelfRepository.addBookToShelf(shelf.id, book1!.id);
+
+      // Add book2 to top via service
+      const result = await shelfService.addBookToShelfAtTop(shelf.id, book2!.id);
+
+      // Verify result
+      expect(result).toBeDefined();
+      expect(result.shelfId).toBe(shelf.id);
+      expect(result.bookId).toBe(book2!.id);
+      expect(result.sortOrder).toBe(0);
+
+      // Verify order in shelf
+      const books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(2);
+      expect(books[0]?.id).toBe(book2!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.id).toBe(book1!.id);
+      expect(books[1]?.sortOrder).toBe(1);
+    });
+
+    test("should add book to top of empty shelf", async () => {
+      // Create shelf
+      const shelf = await shelfRepository.create({
+        name: "Empty Shelf",
+        userId: null,
+      });
+
+      // Create book
+      const book = await bookRepository.create({
+        calibreId: 1,
+        title: "First Book",
+        authors: ["Author"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      // Add book to top
+      const result = await shelfService.addBookToShelfAtTop(shelf.id, book!.id);
+
+      // Verify result
+      expect(result).toBeDefined();
+      expect(result.sortOrder).toBe(0);
+
+      // Verify book is on shelf
+      const books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(1);
+      expect(books[0]?.id).toBe(book!.id);
+    });
+
+    test("should handle multiple consecutive adds to top", async () => {
+      // Create shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create three books
+      const books = [];
+      for (let i = 1; i <= 3; i++) {
+        const book = await bookRepository.create({
+          calibreId: i,
+          title: `Book ${i}`,
+          authors: [`Author ${i}`],
+          tags: [],
+          path: `/path/${i}`,
+        });
+        books.push(book);
+      }
+
+      // Add all books to top via service
+      for (const book of books) {
+        await shelfService.addBookToShelfAtTop(shelf.id, book!.id);
+      }
+
+      // Verify final order (reverse of add order)
+      const shelfBooks = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(shelfBooks).toHaveLength(3);
+      expect(shelfBooks[0]?.id).toBe(books[2]!.id); // Last added is first
+      expect(shelfBooks[1]?.id).toBe(books[1]!.id);
+      expect(shelfBooks[2]?.id).toBe(books[0]!.id); // First added is last
+    });
+
+    test("should handle adding to shelf with existing books at various positions", async () => {
+      // Create shelf
+      const shelf = await shelfRepository.create({
+        name: "Test Shelf",
+        userId: null,
+      });
+
+      // Create books
+      const book1 = await bookRepository.create({
+        calibreId: 1,
+        title: "Book 1",
+        authors: ["Author 1"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      const book2 = await bookRepository.create({
+        calibreId: 2,
+        title: "Book 2",
+        authors: ["Author 2"],
+        tags: [],
+        path: "/path/2",
+      });
+
+      const book3 = await bookRepository.create({
+        calibreId: 3,
+        title: "Book 3",
+        authors: ["Author 3"],
+        tags: [],
+        path: "/path/3",
+      });
+
+      const newBook = await bookRepository.create({
+        calibreId: 4,
+        title: "New Book",
+        authors: ["Author 4"],
+        tags: [],
+        path: "/path/4",
+      });
+
+      // Add books to shelf at specific positions
+      await shelfRepository.addBookToShelf(shelf.id, book1!.id, 0);
+      await shelfRepository.addBookToShelf(shelf.id, book2!.id, 5);
+      await shelfRepository.addBookToShelf(shelf.id, book3!.id, 10);
+
+      // Add new book to top via service
+      await shelfService.addBookToShelfAtTop(shelf.id, newBook!.id);
+
+      // Verify new book is at top and others shifted
+      const books = await shelfRepository.getBooksOnShelf(shelf.id, "sortOrder", "asc");
+      expect(books).toHaveLength(4);
+      expect(books[0]?.id).toBe(newBook!.id);
+      expect(books[0]?.sortOrder).toBe(0);
+      expect(books[1]?.sortOrder).toBe(1);
+      expect(books[2]?.sortOrder).toBe(6);
+      expect(books[3]?.sortOrder).toBe(11);
+    });
+
+    test("should throw error with shelf name in message", async () => {
+      // Create shelf with specific name
+      const shelf = await shelfRepository.create({
+        name: "My Favorite Books",
+        userId: null,
+      });
+
+      // Create book
+      const book = await bookRepository.create({
+        calibreId: 1,
+        title: "Test Book",
+        authors: ["Author"],
+        tags: [],
+        path: "/path/1",
+      });
+
+      // Add book to shelf
+      await shelfRepository.addBookToShelf(shelf.id, book!.id);
+
+      // Try to add again via service
+      await expect(async () => {
+        await shelfService.addBookToShelfAtTop(shelf.id, book!.id);
+      }).rejects.toThrow('Book is already on shelf "My Favorite Books"');
+    });
+  });
+});

--- a/components/BookDetail/ShelfEditor.tsx
+++ b/components/BookDetail/ShelfEditor.tsx
@@ -18,7 +18,7 @@ interface Shelf {
 interface ShelfEditorProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (shelfIds: number[]) => Promise<void>;
+  onSave: (shelfIds: number[], addToTop: boolean) => Promise<void>;
   bookTitle: string;
   currentShelfIds: number[];
   availableShelves: Shelf[];
@@ -37,6 +37,7 @@ export default function ShelfEditor({
   const [selectedShelfIds, setSelectedShelfIds] = useState<number[]>(currentShelfIds);
   const [saving, setSaving] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [addToTop, setAddToTop] = useState(false);
 
   // Reset state when modal opens
   useEffect(() => {
@@ -44,6 +45,7 @@ export default function ShelfEditor({
       setSelectedShelfIds(currentShelfIds);
       setSaving(false);
       setFilterQuery("");
+      setAddToTop(false);
     }
   }, [isOpen, currentShelfIds]);
 
@@ -58,7 +60,7 @@ export default function ShelfEditor({
   const handleSave = async () => {
     setSaving(true);
     try {
-      await onSave(selectedShelfIds);
+      await onSave(selectedShelfIds, addToTop);
       onClose();
     } catch (error) {
       // Error is handled by the parent component with toast
@@ -72,6 +74,7 @@ export default function ShelfEditor({
     if (!saving) {
       setSelectedShelfIds(currentShelfIds);
       setFilterQuery("");
+      setAddToTop(false);
       onClose();
     }
   };
@@ -189,6 +192,27 @@ export default function ShelfEditor({
             <Plus className="w-4 h-4" />
             Create Shelf
           </a>
+        </div>
+      )}
+
+      {/* Add to Top Option */}
+      {filteredShelves.length > 0 && (
+        <div className="flex items-center gap-2 px-1 mb-4">
+          <input
+            type="checkbox"
+            id="addToTop"
+            checked={addToTop}
+            onChange={(e) => setAddToTop(e.target.checked)}
+            disabled={saving}
+            className="w-4 h-4 rounded border-[var(--border-color)] focus:ring-2 focus:ring-[var(--accent)] focus:ring-offset-0 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ accentColor: 'var(--accent)' }}
+          />
+          <label
+            htmlFor="addToTop"
+            className="text-sm text-[var(--foreground)] cursor-pointer select-none"
+          >
+            Add to top of shelf
+          </label>
         </div>
       )}
 

--- a/lib/api/domains/book/api.ts
+++ b/lib/api/domains/book/api.ts
@@ -29,6 +29,8 @@ import type {
   UpdateBookResponse,
   UpdateTagsRequest,
   UpdateTagsResponse,
+  UpdateBookShelvesRequest,
+  UpdateBookShelvesResponse,
 } from "./types";
 
 /**
@@ -389,6 +391,32 @@ export const bookApi = {
   ): Promise<UpdateTagsResponse> => {
     return baseApiClient["patch"]<UpdateTagsRequest, UpdateTagsResponse>(
       `/api/books/${bookId}/tags`,
+      request
+    );
+  },
+
+  /**
+   * Update which shelves contain a book
+   * 
+   * @param bookId - The ID of the book
+   * @param request - Shelf update request (shelfIds array and optional addToTop flag)
+   * @returns Update result with counts
+   * @throws {ApiError} When request fails
+   * 
+   * @example
+   * // Add book to shelves at the end (default)
+   * await bookApi.updateShelves('123', { shelfIds: [1, 2, 3] });
+   * 
+   * @example
+   * // Add book to shelves at the top (position 0)
+   * await bookApi.updateShelves('123', { shelfIds: [1, 2, 3], addToTop: true });
+   */
+  updateShelves: (
+    bookId: string | number,
+    request: UpdateBookShelvesRequest
+  ): Promise<UpdateBookShelvesResponse> => {
+    return baseApiClient["put"]<UpdateBookShelvesRequest, UpdateBookShelvesResponse>(
+      `/api/books/${bookId}/shelves`,
       request
     );
   },

--- a/lib/api/domains/book/types.ts
+++ b/lib/api/domains/book/types.ts
@@ -262,3 +262,26 @@ export interface UpdateTagsResponse {
   success: boolean;
   book: BookDetail;
 }
+
+// ============================================================================
+// Shelf Management API Types
+// ============================================================================
+
+/**
+ * Request to update which shelves contain a book
+ */
+export interface UpdateBookShelvesRequest {
+  shelfIds: number[];
+  addToTop?: boolean;
+}
+
+/**
+ * Response from updating book shelves
+ */
+export interface UpdateBookShelvesResponse {
+  success: boolean;
+  data: {
+    added: number;
+    removed: number;
+  };
+}


### PR DESCRIPTION
## Summary
Adds an optional checkbox in the ShelfEditor modal that allows users to add books to the beginning (position 0) of a shelf instead of always appending to the end.

## Changes
- **Repository Layer**: Added `addBookToShelfAtTop()` method with transaction-based shifting
- **Service Layer**: Added validation wrapper for the new repository method
- **API Layer**: Updated `PUT /api/books/[id]/shelves` to accept optional `addToTop` parameter
- **UI Layer**: Added checkbox to ShelfEditor component with label "Add to top of shelf"
- **API Client**: Added `bookApi.updateShelves()` for type-safe shelf management
- **Tests**: Added 15 comprehensive tests (7 repository + 8 service) - all passing

## Implementation Details
- Uses SQLite transaction to ensure atomic shift + insert
- Checkbox defaults to unchecked (maintains current behavior)
- Only applies to newly-added shelves (not existing associations)
- Success toast shows different message when adding to top
- Performance: <500ms for large shelves (tested with 100 books)

## Testing
- ✅ All 2966 tests passing (including 15 new tests)
- ✅ Repository tests cover edge cases (empty shelf, gaps, duplicates, transactions)
- ✅ Service tests cover validation and error handling
- ✅ No breaking changes to existing functionality

## Closes
Closes #267