### PR TITLE
Fix: Choppy drag-and-drop animations on mobile

### DIFF
--- a/components/Books/DraggableBookList.tsx
+++ b/components/Books/DraggableBookList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, ReactNode } from "react";
+import { useState, useEffect, useRef, ReactNode } from "react";
 import {
   DndContext,
   closestCenter,
@@ -119,14 +119,17 @@ export function DraggableBookList({
 }: DraggableBookListProps) {
   const [activeId, setActiveId] = useState<number | null>(null);
   const [localBooks, setLocalBooks] = useState(books);
+  const isDraggingRef = useRef(false);
 
   // Disable drag when in select mode
   const effectiveIsDragEnabled = isDragEnabled && !isSelectMode;
 
-  // Update local state when books prop changes
-  if (books !== localBooks) {
-    setLocalBooks(books);
-  }
+  // Update local state when books prop changes (but not during active drag)
+  useEffect(() => {
+    if (!isDraggingRef.current) {
+      setLocalBooks(books);
+    }
+  }, [books]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -146,6 +149,7 @@ export function DraggableBookList({
   );
 
   const handleDragStart = (event: DragStartEvent) => {
+    isDraggingRef.current = true;
     setActiveId(event.active.id as number);
   };
 
@@ -163,10 +167,12 @@ export function DraggableBookList({
       onReorder(newBooks.map((book) => book.id));
     }
 
+    isDraggingRef.current = false;
     setActiveId(null);
   };
 
   const handleDragCancel = () => {
+    isDraggingRef.current = false;
     setActiveId(null);
   };
 

--- a/components/Books/DraggableBookTable.tsx
+++ b/components/Books/DraggableBookTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { BookOpen, Star, ArrowUpDown, ArrowUp, ArrowDown, Trash2, ExternalLink, GripVertical } from "lucide-react";
@@ -305,14 +305,17 @@ export function DraggableBookTable({
   const [imageErrors, setImageErrors] = useState<Set<number>>(new Set());
   const [activeId, setActiveId] = useState<number | null>(null);
   const [localBooks, setLocalBooks] = useState(books);
+  const isDraggingRef = useRef(false);
 
   // Disable drag when in select mode
   const effectiveIsDragEnabled = isDragEnabled && !isSelectMode;
 
-  // Update local state when books prop changes
-  if (books !== localBooks) {
-    setLocalBooks(books);
-  }
+  // Update local state when books prop changes (but not during active drag)
+  useEffect(() => {
+    if (!isDraggingRef.current) {
+      setLocalBooks(books);
+    }
+  }, [books]);
 
   // Check if all visible books are selected
   const allSelected = books.length > 0 && books.every((book) => selectedBookIds.has(book.id));
@@ -384,6 +387,7 @@ export function DraggableBookTable({
   };
 
   const handleDragStart = (event: DragStartEvent) => {
+    isDraggingRef.current = true;
     setActiveId(event.active.id as number);
   };
 
@@ -402,10 +406,12 @@ export function DraggableBookTable({
       }
     }
 
+    isDraggingRef.current = false;
     setActiveId(null);
   };
 
   const handleDragCancel = () => {
+    isDraggingRef.current = false;
     setActiveId(null);
   };
 


### PR DESCRIPTION
## Summary

Fixes choppy drag-and-drop animations on `/shelves/:id` and `/read-next` pages. Items no longer "snap back" to their original position during drag operations.

### Problem
Both `DraggableBookList` and `DraggableBookTable` components used render-time state synchronization:
```typescript
if (books !== localBooks) {
  setLocalBooks(books);
}
```

This pattern conflicted with React Query's optimistic updates, causing:
1. User drags item → Local state updates
2. `onReorder()` triggers optimistic update in React Query
3. React Query updates `books` prop → Component re-renders
4. State sync triggers → Local state overwritten **during active drag**
5. Visual "snap back" → Item returns to original position
6. React Query settles → Item jumps to final position

### Solution
Replaced render-time state sync with `useEffect` hooks that respect active drag state:
- Added `isDraggingRef` to track when drag is in progress
- State only syncs when `isDraggingRef.current === false`
- Prevents external updates from interfering with user interaction

### Changes
- **DraggableBookList.tsx**: Added `isDraggingRef` and `useEffect` for state sync
- **DraggableBookTable.tsx**: Added `isDraggingRef` and `useEffect` for state sync

### Testing
- ✅ Build passes with no TypeScript errors
- ✅ Pattern follows React best practices for interaction state
- ✅ Compatible with existing optimistic update patterns

### Manual Testing Required
Please verify:
- [ ] `/shelves/:id` mobile - smooth drag with no snap-back
- [ ] `/shelves/:id` desktop - smooth drag with no snap-back  
- [ ] `/read-next` mobile - smooth drag with no snap-back
- [ ] `/read-next` desktop - smooth drag with no snap-back
- [ ] Filtering disables drag properly
- [ ] Select mode disables drag properly
- [ ] External updates still sync when not dragging

### Risk Assessment
**Low Risk**:
- Changes isolated to two components
- No API or data layer changes
- Easy to revert if issues arise
- Pattern is well-established in React ecosystem

### Related
Affects: Shelf management and read-next queue UX