### PR TITLE
Fix backup retention to use folder-based logic instead of file-based

### DIFF
--- a/scripts/list-backups.ts
+++ b/scripts/list-backups.ts
@@ -92,7 +92,7 @@ async function main() {
     console.log("Summary:");
     console.log(`  Total backups: ${allBackups.length}`);
     console.log(`  Total size: ${totalSizeMB}MB`);
-    console.log(`  Retention policy: Last ${cfg.maxBackups} backups per database`);
+    console.log(`  Retention policy: Last ${cfg.maxBackups} backup folders (date-based)`);
     console.log("");
     
     if (allBackups.length > cfg.maxBackups * 2) {


### PR DESCRIPTION
## Summary

Changes backup cleanup logic from file-based to folder-based retention. Previously, `cleanupOldBackups()` kept the N most recent **backup files** across all date folders. With multiple databases (tome.db + metadata.db), this caused retention to be per-file rather than per-backup-session.

Now the logic operates on **date folders** (YYYY-MM-DD format), keeping the N most recent folders and deleting entire folders beyond the retention limit.

## Changes

- **lib/db/backup.ts**: Refactored `cleanupOldBackups()` to identify date folders instead of individual files, sort by folder name, and delete entire folders beyond maxBackups
- **__tests__/lib/db/backup.test.ts**: Updated test suite to validate folder-based retention behavior with new edge case tests
- **scripts/list-backups.ts**: Updated retention policy display message to "backup folders (date-based)"

## Behavior Change

**Before (file-based):**
- With `MAX_BACKUPS=6` and 2 databases per backup session
- Kept 6 individual files across all dates
- Could result in incomplete backup sessions (tome.db from one date, metadata.db from another)

**After (folder-based):**
- With `MAX_BACKUPS=6`
- Keeps 6 most recent date folders (e.g., backups/2026-01-15/, 2026-01-14/, etc.)
- All databases from a backup session stay together
- Ensures backup consistency

## Test plan

- [x] All 49 backup tests pass
- [x] Folder-based retention correctly keeps N most recent date folders
- [x] Entire folders (all files) are deleted beyond retention limit
- [x] Edge cases handled (invalid folder names, empty folders, mixed content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)