### PR TITLE
Fix tags API response format for tag search in Edit Tags modal

### DIFF
--- a/__tests__/e2e/api/tags/tags-get-all.test.ts
+++ b/__tests__/e2e/api/tags/tags-get-all.test.ts
@@ -1,0 +1,216 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { bookRepository } from "@/lib/repositories";
+import { setupTestDatabase, teardownTestDatabase, clearTestDatabase } from "@/__tests__/helpers/db-setup";
+import { GET } from "@/app/api/tags/route";
+
+/**
+ * GET /api/tags Endpoint Tests
+ * 
+ * Tests the GET /api/tags endpoint which returns all unique tags
+ * from all books in the library.
+ * 
+ * Coverage:
+ * - Returns tags in correct format { tags: string[] }
+ * - Returns unique tags only (no duplicates)
+ * - Returns empty array when no books exist
+ * - Includes tags from all books
+ */
+
+beforeAll(async () => {
+  await setupTestDatabase(__filename);
+});
+
+afterAll(async () => {
+  await teardownTestDatabase(__filename);
+});
+
+beforeEach(async () => {
+  await clearTestDatabase(__filename);
+});
+
+describe("GET /api/tags", () => {
+  test("should return tags in correct format with { tags: string[] }", async () => {
+    // Create books with tags
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: ["Fantasy", "Adventure"],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    await bookRepository.create({
+      calibreId: 2,
+      title: "Book 2",
+      authors: ["Author 2"],
+      tags: ["Science Fiction", "Space Opera"],
+      path: "Author 2/Book 2 (2)",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    // Verify response structure
+    expect(data).toHaveProperty("tags");
+    expect(Array.isArray(data.tags)).toBe(true);
+    expect(data.tags.length).toBeGreaterThan(0);
+  });
+
+  test("should return all unique tags from all books", async () => {
+    // Create books with various tags
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: ["Fantasy", "Adventure", "Magic"],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    await bookRepository.create({
+      calibreId: 2,
+      title: "Book 2",
+      authors: ["Author 2"],
+      tags: ["Science Fiction", "Space Opera"],
+      path: "Author 2/Book 2 (2)",
+    });
+
+    await bookRepository.create({
+      calibreId: 3,
+      title: "Book 3",
+      authors: ["Author 3"],
+      tags: ["Fantasy", "Epic"],
+      path: "Author 3/Book 3 (3)",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    // Verify all unique tags are included
+    expect(data.tags).toContain("Fantasy");
+    expect(data.tags).toContain("Adventure");
+    expect(data.tags).toContain("Magic");
+    expect(data.tags).toContain("Science Fiction");
+    expect(data.tags).toContain("Space Opera");
+    expect(data.tags).toContain("Epic");
+
+    // Verify no duplicates (Fantasy appears in 2 books but should only be listed once)
+    const uniqueTags = new Set(data.tags);
+    expect(data.tags.length).toBe(uniqueTags.size);
+  });
+
+  test("should return empty array when no books exist", async () => {
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).toHaveProperty("tags");
+    expect(data.tags).toEqual([]);
+  });
+
+  test("should return empty array when books have no tags", async () => {
+    // Create books without tags
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: [],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    await bookRepository.create({
+      calibreId: 2,
+      title: "Book 2",
+      authors: ["Author 2"],
+      tags: [],
+      path: "Author 2/Book 2 (2)",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data).toHaveProperty("tags");
+    expect(data.tags).toEqual([]);
+  });
+
+  test("should handle books with mixed empty and non-empty tags", async () => {
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: ["Fantasy", "Magic"],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    await bookRepository.create({
+      calibreId: 2,
+      title: "Book 2",
+      authors: ["Author 2"],
+      tags: [],
+      path: "Author 2/Book 2 (2)",
+    });
+
+    await bookRepository.create({
+      calibreId: 3,
+      title: "Book 3",
+      authors: ["Author 3"],
+      tags: ["Science Fiction"],
+      path: "Author 3/Book 3 (3)",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.tags).toContain("Fantasy");
+    expect(data.tags).toContain("Magic");
+    expect(data.tags).toContain("Science Fiction");
+    expect(data.tags.length).toBe(3);
+  });
+
+  test("should return tags with special characters correctly", async () => {
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: ["Science Fiction & Fantasy", "High-Tech", "Books & Reading"],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(data.tags).toContain("Science Fiction & Fantasy");
+    expect(data.tags).toContain("High-Tech");
+    expect(data.tags).toContain("Books & Reading");
+  });
+
+  test("should handle case-sensitive tags as distinct values", async () => {
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: ["fantasy", "Fantasy", "FANTASY"],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    const response = await GET();
+    const data = await response.json();
+
+    // Tags should be treated as case-sensitive and all three should be present
+    expect(data.tags).toContain("fantasy");
+    expect(data.tags).toContain("Fantasy");
+    expect(data.tags).toContain("FANTASY");
+  });
+
+  test("should return 200 status code on success", async () => {
+    await bookRepository.create({
+      calibreId: 1,
+      title: "Book 1",
+      authors: ["Author 1"],
+      tags: ["Fantasy"],
+      path: "Author 1/Book 1 (1)",
+    });
+
+    const response = await GET();
+    
+    expect(response.status).toBe(200);
+  });
+});

--- a/app/api/tags/route.ts
+++ b/app/api/tags/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
     const tagStats = await tagService.getTagStats();
     const tags = tagStats.map(stat => stat.name);
 
-    return NextResponse.json(tags);
+    return NextResponse.json({ tags });
   } catch (error) {
     getLogger().error({ err: error }, "Error fetching tags");
     return NextResponse.json({ error: "Failed to fetch tags" }, { status: 500 });

--- a/lib/library-service.ts
+++ b/lib/library-service.ts
@@ -139,8 +139,8 @@ export class LibraryService {
       }
 
       const data = await response.json();
-      // API returns tags array directly, not wrapped in { tags: [...] }
-      const tags = Array.isArray(data) ? data : (data.tags || []);
+      // API now returns { tags: [...] } format
+      const tags = data.tags || [];
       const sortedTags = tags.sort((a: string, b: string) => a.localeCompare(b));
 
       // Cache the result


### PR DESCRIPTION
## Summary

- Fixes tag search/suggestions not working in the Edit Tags modal on book detail page
- Changes GET /api/tags to return `{ tags: string[] }` instead of plain array
- Updates LibraryService to expect the new format
- Adds comprehensive test coverage (8 new tests)

## Problem

The tag search feature in the Edit Tags modal was not working because:

1. The book detail page expected the API to return `{ tags: string[] }`
2. The API was returning a plain array `string[]`
3. This mismatch caused `availableTags` to always be empty
4. Empty suggestions list meant tag search didn't work

## Solution

**Changed API response format** (app/api/tags/route.ts):
```typescript
// Before:
return NextResponse.json(tags);  // ["tag1", "tag2"]

// After:
return NextResponse.json({ tags });  // { tags: ["tag1", "tag2"] }
```

**Updated LibraryService** (lib/library-service.ts):
- Removed defensive array handling that worked around the inconsistency
- Now expects object format consistently

**Added Tests** (__tests__/e2e/api/tags/tags-get-all.test.ts):
- 8 comprehensive tests covering all edge cases
- Validates response format, uniqueness, special characters, etc.

## Testing

✅ All 3278 existing tests pass
✅ 8 new tests added and passing
✅ Manual verification: Tag search now works in Edit Tags modal

## Related

This standardizes the API response format following REST best practices and makes it consistent with other Tome API endpoints.