### PR TITLE
Add read-only demo site infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,8 @@ LOG_PRETTY=true
 # Authentication (optional)
 # Set a password to enable authentication. Leave empty or unset to disable.
 # AUTH_PASSWORD=your-secure-password
+
+# Demo Mode (optional)
+# Enable read-only demo mode. All data mutations will be blocked.
+# Useful for public demo sites to prevent changes to sample data.
+# DEMO_MODE=true

--- a/.github/workflows/demo-image.yml
+++ b/.github/workflows/demo-image.yml
@@ -1,0 +1,72 @@
+name: Build and Publish Demo Image
+
+on:
+  # Trigger on new releases
+  release:
+    types: [published]
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag for the demo image (default: demo)'
+        required: false
+        default: 'demo'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-demo:
+    name: Build and Push Demo Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine tags
+        id: tags
+        run: |
+          # Base tag is always 'demo'
+          TAGS="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:demo"
+
+          # On release, also tag with version-demo
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}-demo"
+          fi
+
+          # On manual trigger with custom tag
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.tag }}" != "demo" ]; then
+            TAGS="$TAGS,${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.inputs.tag }}"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+
+      - name: Build and push Demo Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.demo
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=Tome Demo
+            org.opencontainers.image.description=Read-only demo of Tome with sample data
+          cache-from: type=gha,scope=demo
+          cache-to: type=gha,mode=max,scope=demo
+          platforms: linux/amd64

--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -1,0 +1,101 @@
+# Demo image - includes pre-seeded database with public domain classics
+# Build: docker build -f Dockerfile.demo -t tome:demo .
+
+# Use Node.js LTS image
+FROM node:22-alpine AS base
+WORKDIR /app
+
+# Install build dependencies for better-sqlite3 native module
+RUN apk add --no-cache python3 make g++ bash
+
+# Install dependencies
+FROM base AS deps
+COPY package.json package-lock.json ./
+RUN npm ci --legacy-peer-deps
+
+# Install production dependencies only
+FROM base AS prod-deps
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --legacy-peer-deps
+
+# Install migration dependencies
+FROM base AS migration-deps
+RUN npm install \
+  drizzle-orm@^0.44.7 \
+  pino@^9.3.1 \
+  tsx@^4.7.0 \
+  better-sqlite3@^12.4.1 \
+  date-fns@^3.3.0 \
+  date-fns-tz@^3.2.0 \
+  dotenv@^16.0.0
+
+# Build the application
+FROM base AS builder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Create data directory
+RUN mkdir -p data
+
+RUN npm run build
+
+# Seed the demo database during build
+FROM base AS seeder
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Create data directory and run migrations + seeding
+RUN mkdir -p data
+ENV DATABASE_PATH=/app/data/tome.db
+RUN npx tsx scripts/seed-demo.ts
+
+# Production image
+FROM base AS runner
+WORKDIR /app
+
+# Install sqlite3 CLI for debugging
+RUN apk add --no-cache sqlite
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV DATABASE_PATH=/app/data/tome.db
+ENV NODE_OPTIONS="--enable-source-maps"
+
+# Demo mode settings
+ENV DEMO_MODE=true
+
+# Create non-root user
+RUN addgroup -g 1001 -S nodejs
+RUN adduser -u 1001 -S nextjs -G nodejs
+
+# Create data directory and set permissions
+RUN mkdir -p data && chown -R nextjs:nodejs data
+
+# Copy built application
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Copy database files and migration scripts
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+COPY --from=builder --chown=nextjs:nodejs /app/lib ./lib
+COPY --from=builder --chown=nextjs:nodejs /app/scripts ./scripts
+COPY --from=builder --chown=nextjs:nodejs /app/tsconfig.json ./tsconfig.json
+
+# Copy pre-seeded demo database from seeder stage
+COPY --from=seeder --chown=nextjs:nodejs /app/data/tome.db ./data/tome.db
+
+# Copy migration dependencies
+COPY --from=migration-deps --chown=nextjs:nodejs /app/node_modules ./node_modules
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# Use TypeScript entrypoint
+CMD ["npx", "tsx", "scripts/entrypoint.ts"]

--- a/app/api/demo/status/route.ts
+++ b/app/api/demo/status/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { getDemoConfig } from "@/lib/demo";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return NextResponse.json(getDemoConfig());
+}

--- a/components/Layout/DemoBanner.tsx
+++ b/components/Layout/DemoBanner.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useDemo } from "@/lib/contexts/DemoContext";
+import { Info, Github } from "lucide-react";
+
+export function DemoBanner() {
+  const { isDemoMode, mounted } = useDemo();
+
+  // Don't render anything until mounted and demo mode is confirmed
+  if (!mounted || !isDemoMode) {
+    return null;
+  }
+
+  return (
+    <div className="bg-[var(--accent)] text-white px-4 py-2 text-sm flex items-center justify-center gap-2 sticky top-0 z-50">
+      <Info className="w-4 h-4 flex-shrink-0" />
+      <span>This is a read-only demo. Changes are not saved.</span>
+      <a
+        href="https://github.com/masonfox/tome"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1 underline hover:no-underline ml-2"
+      >
+        <Github className="w-4 h-4" />
+        <span>Self-host your own</span>
+      </a>
+    </div>
+  );
+}

--- a/components/Layout/LayoutWrapper.tsx
+++ b/components/Layout/LayoutWrapper.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { BottomNavigation } from "@/components/Layout/BottomNavigation";
+import { DemoBanner } from "@/components/Layout/DemoBanner";
 import { DesktopSidebar } from "@/components/Layout/DesktopSidebar";
 import { PullToRefreshWrapper } from "@/components/Layout/PullToRefreshWrapper";
 import { AuthProvider } from "@/lib/contexts/AuthContext";
+import { DemoProvider } from "@/lib/contexts/DemoContext";
 import { usePathname } from "next/navigation";
 
 export function LayoutWrapper({ children }: { children: React.ReactNode }) {
@@ -15,24 +17,29 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthProvider>
-      {/* Desktop Sidebar - visible on md+ screens */}
-      <DesktopSidebar />
+    <DemoProvider>
+      <AuthProvider>
+        {/* Demo Mode Banner - visible when DEMO_MODE=true */}
+        <DemoBanner />
 
-      {/* Main Content with Pull-to-Refresh */}
-      <PullToRefreshWrapper>
-        <main
-          id="main-content"
-          className="px-6 py-8 pb-32 md:px-0 md:py-12"
-        >
-          {children}
-        </main>
-      </PullToRefreshWrapper>
+        {/* Desktop Sidebar - visible on md+ screens */}
+        <DesktopSidebar />
 
-      {/* Bottom Navigation - visible on mobile only (<md) */}
-      <div className="md:hidden">
-        <BottomNavigation />
-      </div>
-    </AuthProvider>
+        {/* Main Content with Pull-to-Refresh */}
+        <PullToRefreshWrapper>
+          <main
+            id="main-content"
+            className="px-6 py-8 pb-32 md:px-0 md:py-12"
+          >
+            {children}
+          </main>
+        </PullToRefreshWrapper>
+
+        {/* Bottom Navigation - visible on mobile only (<md) */}
+        <div className="md:hidden">
+          <BottomNavigation />
+        </div>
+      </AuthProvider>
+    </DemoProvider>
   );
 }

--- a/lib/contexts/DemoContext.tsx
+++ b/lib/contexts/DemoContext.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+
+interface DemoContextType {
+  isDemoMode: boolean;
+  demoMessage: string;
+  mounted: boolean;
+}
+
+const DemoContext = createContext<DemoContextType>({
+  isDemoMode: false,
+  demoMessage: "",
+  mounted: false,
+});
+
+export function DemoProvider({ children }: { children: ReactNode }) {
+  const [isDemoMode, setIsDemoMode] = useState(false);
+  const [demoMessage, setDemoMessage] = useState("");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    fetch("/api/demo/status")
+      .then((res) => res.json())
+      .then((data) => {
+        setIsDemoMode(data.enabled);
+        setDemoMessage(data.message || "");
+      })
+      .catch(() => {
+        setIsDemoMode(false);
+        setDemoMessage("");
+      });
+  }, []);
+
+  return (
+    <DemoContext.Provider value={{ isDemoMode, demoMessage, mounted }}>
+      {children}
+    </DemoContext.Provider>
+  );
+}
+
+export function useDemo() {
+  const context = useContext(DemoContext);
+  if (context === undefined) {
+    throw new Error("useDemo must be used within a DemoProvider");
+  }
+  return context;
+}

--- a/lib/demo.ts
+++ b/lib/demo.ts
@@ -1,0 +1,17 @@
+/**
+ * Demo mode utilities
+ *
+ * When DEMO_MODE=true, the application runs in read-only mode.
+ * All data mutations are blocked at the middleware level.
+ */
+
+export function isDemoMode(): boolean {
+  return process.env.DEMO_MODE === "true";
+}
+
+export function getDemoConfig() {
+  return {
+    enabled: isDemoMode(),
+    message: "This is a read-only demo. Changes are not saved.",
+  };
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "db:push": "DATABASE_PATH=./data/tome.db npx drizzle-kit push",
     "db:studio": "DATABASE_PATH=./data/tome.db npx drizzle-kit studio",
     "db:seed": "tsx scripts/seed.ts",
+    "db:seed:demo": "tsx scripts/seed-demo.ts",
     "db:reset": "bash scripts/reset-database.sh",
     "sync-calibre": "tsx scripts/sync-calibre.ts",
     "test": "TZ=UTC vitest run",

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,14 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { proxyAuthCheck } from "@/lib/auth";
 
+const DEMO_MODE = process.env.DEMO_MODE === "true";
+
+// HTTP methods that modify data
+const MUTATION_METHODS = ["POST", "PUT", "DELETE", "PATCH"];
+
+// API routes allowed even in demo mode
+const DEMO_ALLOWED_ROUTES = ["/api/auth/login", "/api/auth/logout", "/api/auth/status", "/api/demo/status"];
+
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -13,6 +21,23 @@ export function proxy(request: NextRequest) {
   // Skip Next.js internals
   if (pathname.startsWith('/_next')) {
     return NextResponse.next();
+  }
+
+  // Demo mode: block mutation requests on API routes
+  if (DEMO_MODE && MUTATION_METHODS.includes(request.method) && pathname.startsWith("/api/")) {
+    // Allow whitelisted routes
+    if (DEMO_ALLOWED_ROUTES.some((route) => pathname.startsWith(route))) {
+      return NextResponse.next();
+    }
+
+    // Block all other mutations with a friendly error
+    return NextResponse.json(
+      {
+        error: "This is a read-only demo. Changes are not saved.",
+        demo: true,
+      },
+      { status: 403 }
+    );
   }
 
   const authResult = proxyAuthCheck(request);

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -1,0 +1,519 @@
+#!/usr/bin/env node
+
+/**
+ * Demo database seeding script
+ * Creates a realistic reading library using public domain classics
+ * No Calibre connection required - books are created directly
+ *
+ * Usage:
+ *   bun run scripts/seed-demo.ts
+ *   npm run db:seed:demo
+ */
+
+import { config } from "dotenv";
+config();
+
+import { bookRepository, sessionRepository, progressRepository, readingGoalRepository } from "@/lib/repositories";
+import { shelfRepository } from "@/lib/repositories/shelf.repository";
+import { rebuildStreak } from "@/lib/streaks";
+import { format, subDays, subMonths } from "date-fns";
+
+// Public domain classics for the demo
+const DEMO_BOOKS = [
+  {
+    title: "Pride and Prejudice",
+    authors: ["Jane Austen"],
+    authorSort: "Austen, Jane",
+    totalPages: 432,
+    pubDate: new Date("1813-01-28"),
+    publisher: "T. Egerton",
+    description: "A witty comedy of manners that follows the turbulent relationship between Elizabeth Bennet and Mr. Darcy.",
+    tags: ["Classic", "Romance", "British Literature"],
+  },
+  {
+    title: "Moby-Dick",
+    authors: ["Herman Melville"],
+    authorSort: "Melville, Herman",
+    totalPages: 654,
+    pubDate: new Date("1851-10-18"),
+    publisher: "Harper & Brothers",
+    description: "Captain Ahab's obsessive quest to hunt the white whale that crippled him.",
+    tags: ["Classic", "Adventure", "American Literature"],
+  },
+  {
+    title: "1984",
+    authors: ["George Orwell"],
+    authorSort: "Orwell, George",
+    totalPages: 328,
+    pubDate: new Date("1949-06-08"),
+    publisher: "Secker & Warburg",
+    description: "A dystopian tale of totalitarianism, surveillance, and the struggle for truth.",
+    tags: ["Classic", "Dystopia", "Science Fiction"],
+  },
+  {
+    title: "The Great Gatsby",
+    authors: ["F. Scott Fitzgerald"],
+    authorSort: "Fitzgerald, F. Scott",
+    totalPages: 180,
+    pubDate: new Date("1925-04-10"),
+    publisher: "Charles Scribner's Sons",
+    description: "A portrait of the Jazz Age and the American Dream through the eyes of Nick Carraway.",
+    tags: ["Classic", "American Literature"],
+  },
+  {
+    title: "Jane Eyre",
+    authors: ["Charlotte Brontë"],
+    authorSort: "Brontë, Charlotte",
+    totalPages: 532,
+    pubDate: new Date("1847-10-19"),
+    publisher: "Smith, Elder & Co.",
+    description: "An orphaned governess finds love and independence in Victorian England.",
+    tags: ["Classic", "Romance", "Gothic"],
+  },
+  {
+    title: "Frankenstein",
+    authors: ["Mary Shelley"],
+    authorSort: "Shelley, Mary",
+    totalPages: 280,
+    pubDate: new Date("1818-01-01"),
+    publisher: "Lackington, Hughes, Harding, Mavor & Jones",
+    description: "The story of Victor Frankenstein and the creature he brings to life.",
+    tags: ["Classic", "Gothic", "Science Fiction", "Horror"],
+  },
+  {
+    title: "Dracula",
+    authors: ["Bram Stoker"],
+    authorSort: "Stoker, Bram",
+    totalPages: 418,
+    pubDate: new Date("1897-05-26"),
+    publisher: "Archibald Constable and Company",
+    description: "The legendary vampire Count Dracula attempts to move from Transylvania to England.",
+    tags: ["Classic", "Gothic", "Horror"],
+  },
+  {
+    title: "The Picture of Dorian Gray",
+    authors: ["Oscar Wilde"],
+    authorSort: "Wilde, Oscar",
+    totalPages: 254,
+    pubDate: new Date("1890-07-01"),
+    publisher: "Lippincott's Monthly Magazine",
+    description: "A young man sells his soul for eternal youth while his portrait ages.",
+    tags: ["Classic", "Gothic", "Philosophy"],
+  },
+  {
+    title: "Crime and Punishment",
+    authors: ["Fyodor Dostoevsky"],
+    authorSort: "Dostoevsky, Fyodor",
+    totalPages: 671,
+    pubDate: new Date("1866-01-01"),
+    publisher: "The Russian Messenger",
+    description: "A poor ex-student commits murder and suffers the psychological consequences.",
+    tags: ["Classic", "Russian Literature", "Philosophy"],
+  },
+  {
+    title: "Wuthering Heights",
+    authors: ["Emily Brontë"],
+    authorSort: "Brontë, Emily",
+    totalPages: 416,
+    pubDate: new Date("1847-12-01"),
+    publisher: "Thomas Cautley Newby",
+    description: "A tale of passion and revenge on the Yorkshire moors.",
+    tags: ["Classic", "Romance", "Gothic"],
+  },
+  {
+    title: "The Count of Monte Cristo",
+    authors: ["Alexandre Dumas"],
+    authorSort: "Dumas, Alexandre",
+    totalPages: 1276,
+    pubDate: new Date("1844-01-01"),
+    publisher: "Journal des Débats",
+    description: "An innocent man escapes prison and transforms into a wealthy count seeking revenge.",
+    tags: ["Classic", "Adventure", "French Literature"],
+  },
+  {
+    title: "Les Misérables",
+    authors: ["Victor Hugo"],
+    authorSort: "Hugo, Victor",
+    totalPages: 1463,
+    pubDate: new Date("1862-01-01"),
+    publisher: "A. Lacroix, Verboeckhoven & Cie",
+    description: "The story of Jean Valjean's redemption set against the backdrop of revolutionary France.",
+    tags: ["Classic", "French Literature", "Historical Fiction"],
+  },
+  {
+    title: "A Tale of Two Cities",
+    authors: ["Charles Dickens"],
+    authorSort: "Dickens, Charles",
+    totalPages: 489,
+    pubDate: new Date("1859-04-30"),
+    publisher: "Chapman & Hall",
+    description: "A story of resurrection and revolution in London and Paris.",
+    tags: ["Classic", "Historical Fiction", "British Literature"],
+  },
+  {
+    title: "The Adventures of Sherlock Holmes",
+    authors: ["Arthur Conan Doyle"],
+    authorSort: "Doyle, Arthur Conan",
+    totalPages: 307,
+    pubDate: new Date("1892-10-14"),
+    publisher: "George Newnes",
+    description: "A collection of twelve detective stories featuring Sherlock Holmes and Dr. Watson.",
+    tags: ["Classic", "Mystery", "Detective Fiction"],
+  },
+  {
+    title: "The Scarlet Letter",
+    authors: ["Nathaniel Hawthorne"],
+    authorSort: "Hawthorne, Nathaniel",
+    totalPages: 272,
+    pubDate: new Date("1850-03-16"),
+    publisher: "Ticknor, Reed & Fields",
+    description: "Hester Prynne bears the scarlet 'A' for adultery in Puritan Massachusetts.",
+    tags: ["Classic", "American Literature", "Historical Fiction"],
+  },
+  {
+    title: "Little Women",
+    authors: ["Louisa May Alcott"],
+    authorSort: "Alcott, Louisa May",
+    totalPages: 449,
+    pubDate: new Date("1868-09-30"),
+    publisher: "Roberts Brothers",
+    description: "The March sisters navigate life, love, and growing up during the Civil War.",
+    tags: ["Classic", "American Literature", "Coming of Age"],
+  },
+  {
+    title: "The Odyssey",
+    authors: ["Homer"],
+    authorSort: "Homer",
+    totalPages: 541,
+    pubDate: new Date("-0800-01-01"),
+    publisher: "Ancient Greece",
+    description: "Odysseus's epic journey home after the fall of Troy.",
+    tags: ["Classic", "Epic Poetry", "Ancient Literature", "Mythology"],
+  },
+  {
+    title: "Don Quixote",
+    authors: ["Miguel de Cervantes"],
+    authorSort: "Cervantes, Miguel de",
+    totalPages: 1023,
+    pubDate: new Date("1605-01-16"),
+    publisher: "Juan de la Cuesta",
+    description: "A Spanish gentleman goes mad from reading too many chivalric romances.",
+    tags: ["Classic", "Satire", "Spanish Literature"],
+  },
+  {
+    title: "Anna Karenina",
+    authors: ["Leo Tolstoy"],
+    authorSort: "Tolstoy, Leo",
+    totalPages: 964,
+    pubDate: new Date("1877-01-01"),
+    publisher: "The Russian Messenger",
+    description: "A tragic tale of love and society in Imperial Russia.",
+    tags: ["Classic", "Russian Literature", "Romance"],
+  },
+  {
+    title: "Great Expectations",
+    authors: ["Charles Dickens"],
+    authorSort: "Dickens, Charles",
+    totalPages: 544,
+    pubDate: new Date("1861-08-01"),
+    publisher: "Chapman & Hall",
+    description: "The story of Pip's journey from humble origins to gentleman status.",
+    tags: ["Classic", "British Literature", "Coming of Age"],
+  },
+];
+
+// Demo shelves
+const DEMO_SHELVES = [
+  {
+    name: "Favorites",
+    description: "All-time favorite reads",
+    color: "#ef4444",
+    icon: "heart",
+  },
+  {
+    name: "Classics Challenge",
+    description: "Working through the classics",
+    color: "#8b5cf6",
+    icon: "book",
+  },
+  {
+    name: "Quick Reads",
+    description: "Books under 350 pages",
+    color: "#22c55e",
+    icon: "clock",
+  },
+];
+
+async function seedDemoDatabase() {
+  console.log("\n🌱 Starting demo database seeding...\n");
+
+  try {
+    // Phase 1: Create books
+    console.log("📚 Phase 1: Creating demo books...");
+    const createdBooks: Array<{ id: number; title: string; totalPages: number }> = [];
+
+    for (let i = 0; i < DEMO_BOOKS.length; i++) {
+      const bookData = DEMO_BOOKS[i];
+      const calibreId = 10000 + i;
+
+      // Check if book already exists by calibreId
+      const existing = await bookRepository.findByCalibreId(calibreId);
+      if (existing) {
+        console.log(`  ⏭️  "${bookData.title}" already exists, skipping`);
+        createdBooks.push({ id: existing.id, title: existing.title, totalPages: existing.totalPages || bookData.totalPages });
+        continue;
+      }
+
+      const book = await bookRepository.create({
+        calibreId, // Fake Calibre IDs starting at 10000
+        title: bookData.title,
+        authors: bookData.authors,
+        authorSort: bookData.authorSort,
+        totalPages: bookData.totalPages,
+        pubDate: bookData.pubDate,
+        publisher: bookData.publisher,
+        description: bookData.description,
+        tags: bookData.tags,
+        path: `/demo/${bookData.title.toLowerCase().replace(/\s+/g, "-")}`,
+      });
+
+      createdBooks.push({ id: book.id, title: book.title, totalPages: book.totalPages || bookData.totalPages });
+      console.log(`  ✓ Created "${bookData.title}"`);
+    }
+
+    // Phase 2: Create reading sessions
+    console.log("\n📖 Phase 2: Creating reading sessions...");
+
+    const sessionPlans = [
+      // Currently reading (2 books)
+      { index: 0, status: "reading" as const, progressPercent: 85 },
+      { index: 1, status: "reading" as const, progressPercent: 45 },
+      // Completed (4 books)
+      { index: 2, status: "read" as const, progressPercent: 100 },
+      { index: 3, status: "read" as const, progressPercent: 100 },
+      { index: 4, status: "read" as const, progressPercent: 100 },
+      { index: 5, status: "read" as const, progressPercent: 100 },
+      // DNF (1 book)
+      { index: 6, status: "dnf" as const, progressPercent: 25 },
+      // Read Next (3 books)
+      { index: 7, status: "read-next" as const, progressPercent: 0 },
+      { index: 8, status: "read-next" as const, progressPercent: 0 },
+      { index: 9, status: "read-next" as const, progressPercent: 0 },
+      // To Read (rest)
+      { index: 10, status: "to-read" as const, progressPercent: 0 },
+      { index: 11, status: "to-read" as const, progressPercent: 0 },
+      { index: 12, status: "to-read" as const, progressPercent: 0 },
+      { index: 13, status: "to-read" as const, progressPercent: 0 },
+      { index: 14, status: "to-read" as const, progressPercent: 0 },
+    ];
+
+    const sessions: Array<{ bookId: number; sessionId: number; status: string; totalPages: number; progressPercent: number }> = [];
+    let sessionsCreated = 0;
+
+    for (const plan of sessionPlans) {
+      if (plan.index >= createdBooks.length) continue;
+
+      const book = createdBooks[plan.index];
+
+      // Check for existing session
+      const existingSession = await sessionRepository.findActiveByBookId(book.id);
+      if (existingSession) {
+        sessions.push({
+          bookId: book.id,
+          sessionId: existingSession.id,
+          status: plan.status,
+          totalPages: book.totalPages,
+          progressPercent: plan.progressPercent,
+        });
+        continue;
+      }
+
+      const today = format(new Date(), "yyyy-MM-dd");
+      const weeksAgo = (weeks: number) => format(subDays(new Date(), weeks * 7), "yyyy-MM-dd");
+      const monthsAgo = (months: number) => format(subMonths(new Date(), months), "yyyy-MM-dd");
+
+      const sessionNumber = await sessionRepository.getNextSessionNumber(book.id);
+
+      const session = await sessionRepository.create({
+        bookId: book.id,
+        sessionNumber,
+        status: plan.status,
+        startedDate: plan.status === "to-read" ? null : (plan.status === "read" ? monthsAgo(2 + plan.index) : weeksAgo(4)),
+        completedDate: plan.status === "read" ? monthsAgo(1 + plan.index * 0.5) : null,
+        dnfDate: plan.status === "dnf" ? weeksAgo(3) : null,
+      });
+
+      sessions.push({
+        bookId: book.id,
+        sessionId: session.id,
+        status: plan.status,
+        totalPages: book.totalPages,
+        progressPercent: plan.progressPercent,
+      });
+
+      sessionsCreated++;
+      console.log(`  ✓ Created session for "${book.title}" (${plan.status})`);
+    }
+
+    // Phase 3: Create progress logs
+    console.log("\n📊 Phase 3: Creating progress logs...");
+    let progressLogsCreated = 0;
+
+    for (const session of sessions) {
+      if (session.progressPercent === 0) continue;
+
+      const totalPages = session.totalPages;
+      const targetPage = Math.floor((session.progressPercent / 100) * totalPages);
+
+      // Generate progress logs over time
+      const logs: Array<{ bookId: number; sessionId: number; pagesRead: number; currentPage: number; progressDate: string }> = [];
+      let currentPage = 0;
+      const daysBack = session.status === "read" ? 60 : 30;
+
+      // Generate realistic reading pattern
+      for (let day = daysBack; day >= 0 && currentPage < targetPage; day--) {
+        // Random reading days (not every day)
+        if (Math.random() < 0.4) continue;
+
+        const pagesThisSession = Math.min(
+          Math.floor(Math.random() * 60) + 20, // 20-80 pages
+          targetPage - currentPage
+        );
+
+        if (pagesThisSession <= 0) continue;
+
+        currentPage += pagesThisSession;
+        const progressDate = format(subDays(new Date(), day), "yyyy-MM-dd");
+
+        logs.push({
+          bookId: session.bookId,
+          sessionId: session.sessionId,
+          pagesRead: pagesThisSession,
+          currentPage: Math.min(currentPage, targetPage),
+          progressDate,
+        });
+      }
+
+      // Ensure we hit the target
+      if (currentPage < targetPage && logs.length > 0) {
+        logs[logs.length - 1].currentPage = targetPage;
+        logs[logs.length - 1].pagesRead = targetPage - (logs[logs.length - 2]?.currentPage || 0);
+      }
+
+      for (const log of logs) {
+        await progressRepository.create(log);
+        progressLogsCreated++;
+      }
+
+      if (logs.length > 0) {
+        console.log(`  ✓ Created ${logs.length} progress logs for "${createdBooks[sessions.indexOf(session)]?.title || "book"}"`);
+      }
+    }
+
+    // Phase 4: Create reading goals
+    console.log("\n🎯 Phase 4: Creating reading goals...");
+    const currentYear = new Date().getFullYear();
+    const goalsData = [
+      { year: currentYear - 2, booksGoal: 20 },
+      { year: currentYear - 1, booksGoal: 24 },
+      { year: currentYear, booksGoal: 30 },
+      { year: currentYear + 1, booksGoal: 36 },
+    ];
+
+    let goalsCreated = 0;
+    for (const goalData of goalsData) {
+      const existing = await readingGoalRepository.findByUserAndYear(null, goalData.year);
+      if (existing) {
+        console.log(`  ⏭️  Goal for ${goalData.year} already exists`);
+        continue;
+      }
+
+      await readingGoalRepository.create({
+        userId: null,
+        year: goalData.year,
+        booksGoal: goalData.booksGoal,
+      });
+
+      goalsCreated++;
+      console.log(`  ✓ Created goal for ${goalData.year}: ${goalData.booksGoal} books`);
+    }
+
+    // Phase 5: Create shelves
+    console.log("\n📚 Phase 5: Creating shelves...");
+    let shelvesCreated = 0;
+
+    for (const shelfData of DEMO_SHELVES) {
+      const existingShelves = await shelfRepository.findByUserId(null);
+      const exists = existingShelves.find((s) => s.name === shelfData.name);
+
+      if (exists) {
+        console.log(`  ⏭️  Shelf "${shelfData.name}" already exists`);
+        continue;
+      }
+
+      const shelf = await shelfRepository.create({
+        userId: null,
+        name: shelfData.name,
+        description: shelfData.description,
+        color: shelfData.color,
+        icon: shelfData.icon,
+      });
+
+      shelvesCreated++;
+      console.log(`  ✓ Created shelf "${shelfData.name}"`);
+
+      // Add books to shelves based on criteria
+      let booksToAdd: number[] = [];
+
+      if (shelfData.name === "Favorites") {
+        // Add completed books to favorites
+        booksToAdd = sessions.filter((s) => s.status === "read").map((s) => s.bookId).slice(0, 3);
+      } else if (shelfData.name === "Classics Challenge") {
+        // Add currently reading and read-next
+        booksToAdd = sessions.filter((s) => s.status === "reading" || s.status === "read-next").map((s) => s.bookId);
+      } else if (shelfData.name === "Quick Reads") {
+        // Add books under 350 pages
+        booksToAdd = createdBooks.filter((b) => b.totalPages < 350).map((b) => b.id).slice(0, 5);
+      }
+
+      for (const bookId of booksToAdd) {
+        try {
+          await shelfRepository.addBookToShelf(shelf.id, bookId);
+        } catch {
+          // Book may already be on shelf
+        }
+      }
+
+      console.log(`    Added ${booksToAdd.length} books to "${shelfData.name}"`);
+    }
+
+    // Phase 6: Rebuild streak
+    console.log("\n🔥 Phase 6: Rebuilding streak...");
+    const streakResult = await rebuildStreak(null, undefined, true);
+    console.log(`  ✓ Current streak: ${streakResult.currentStreak} days`);
+    console.log(`  ✓ Longest streak: ${streakResult.longestStreak} days`);
+
+    // Summary
+    console.log("\n✅ Demo seeding completed!\n");
+    console.log("Summary:");
+    console.log(`  📚 Books created: ${createdBooks.length}`);
+    console.log(`  📖 Sessions created: ${sessionsCreated}`);
+    console.log(`  📊 Progress logs created: ${progressLogsCreated}`);
+    console.log(`  🎯 Goals created: ${goalsCreated}`);
+    console.log(`  📚 Shelves created: ${shelvesCreated}`);
+    console.log(`  🔥 Current streak: ${streakResult.currentStreak} days\n`);
+
+    process.exit(0);
+  } catch (error) {
+    console.error("\n❌ Demo seeding failed:", error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  seedDemoDatabase();
+}
+
+export { seedDemoDatabase };


### PR DESCRIPTION
## Summary

Implements demo mode for tomeapp.dev (closes #290):

- **Read-only enforcement**: `DEMO_MODE=true` blocks all mutation requests at the proxy level
- **Demo banner**: Shows "This is a read-only demo. Changes are not saved." with link to GitHub
- **Demo seed script**: Populates database with 20 public domain classics (Austen, Melville, Orwell, etc.)
- **Docker image**: `Dockerfile.demo` builds an image with baked-in demo data
- **CI/CD**: GitHub Action publishes `ghcr.io/masonfox/tome:demo` on releases

## Files Changed

| File | Purpose |
|------|---------|
| `proxy.ts` | Demo mode mutation blocking |
| `lib/demo.ts` | Demo mode utility |
| `lib/contexts/DemoContext.tsx` | React context for demo state |
| `app/api/demo/status/route.ts` | API endpoint for demo status |
| `components/Layout/DemoBanner.tsx` | Banner component |
| `components/Layout/LayoutWrapper.tsx` | Integrates DemoProvider and banner |
| `scripts/seed-demo.ts` | Seeds 20 public domain books |
| `Dockerfile.demo` | Demo image with baked-in data |
| `.github/workflows/demo-image.yml` | Publishes to GHCR |

## Test plan

- [x] Build passes
- [x] All 3278 tests pass
- [ ] Test locally with `DEMO_MODE=true` - verify mutations return 403
- [ ] Test demo banner appears
- [ ] Build demo Docker image: `docker build -f Dockerfile.demo -t tome:demo .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)