### PR TITLE
fix: use correct addedAt field for Date Added column on shelf pages

### DIFF
--- a/__tests__/components/Books/DraggableBookTable.test.tsx
+++ b/__tests__/components/Books/DraggableBookTable.test.tsx
@@ -19,7 +19,7 @@ describe("DraggableBookTable", () => {
       rating: 5,
       totalPages: 300,
       addedToLibrary: new Date("2024-01-01"),
-      dateAddedToShelf: new Date("2024-01-02"),
+      addedAt: new Date("2024-01-02"),
       status: "reading",
       sortOrder: 0,
     },
@@ -33,7 +33,7 @@ describe("DraggableBookTable", () => {
       rating: 4,
       totalPages: 250,
       addedToLibrary: new Date("2024-01-03"),
-      dateAddedToShelf: new Date("2024-01-04"),
+      addedAt: new Date("2024-01-04"),
       status: "read",
       sortOrder: 1,
     },
@@ -47,7 +47,7 @@ describe("DraggableBookTable", () => {
       rating: 3,
       totalPages: 400,
       addedToLibrary: new Date("2024-01-05"),
-      dateAddedToShelf: new Date("2024-01-06"),
+      addedAt: new Date("2024-01-06"),
       status: "to-read",
       sortOrder: 2,
     },
@@ -500,7 +500,7 @@ describe("DraggableBookTable", () => {
       expect(dataRow.textContent).toContain("-");
     });
 
-    test("should render date when dateAddedToShelf is available", () => {
+    test("should render date when addedAt is available", () => {
       render(
         <DraggableBookTable
           books={mockBooks}
@@ -510,7 +510,7 @@ describe("DraggableBookTable", () => {
         />
       );
 
-      // mockBooks[0] has dateAddedToShelf: 2024-01-02
+      // mockBooks[0] has addedAt: 2024-01-02
       // Should display date (format may vary)
       const rows = screen.getAllByRole("row");
       const bookOneRow = rows.find((row) => row.textContent?.includes("Book One"));
@@ -521,7 +521,7 @@ describe("DraggableBookTable", () => {
       const booksWithoutShelfDate = [
         {
           ...mockBooks[0],
-          dateAddedToShelf: null,
+          addedAt: null,
           addedToLibrary: new Date("2024-03-15"),
         },
       ];

--- a/components/Books/BookTable.tsx
+++ b/components/Books/BookTable.tsx
@@ -22,7 +22,7 @@ interface BookTableBook {
   rating?: number | null;
   totalPages?: number | null;
   addedToLibrary?: Date | null;
-  dateAddedToShelf?: Date | null;
+  addedAt?: Date | null;
   status?: string | null;
   sortOrder?: number;
   lastSynced?: Date | string | null;
@@ -333,8 +333,8 @@ export function BookTable({
 
                 {/* Date Added */}
                 <td className="px-4 py-3 text-[var(--foreground)]/80 text-sm">
-                  {book.dateAddedToShelf
-                    ? format(new Date(book.dateAddedToShelf), "MMM dd, yyyy")
+                  {book.addedAt
+                    ? format(new Date(book.addedAt), "MMM dd, yyyy")
                     : book.addedToLibrary
                     ? format(new Date(book.addedToLibrary), "MMM dd, yyyy")
                     : "-"}

--- a/components/Books/DraggableBookTable.tsx
+++ b/components/Books/DraggableBookTable.tsx
@@ -41,7 +41,7 @@ interface BookTableBook {
   rating?: number | null;
   totalPages?: number | null;
   addedToLibrary?: Date | null;
-  dateAddedToShelf?: Date | null;
+  addedAt?: Date | null;
   status?: string | null;
   sortOrder?: number;
   lastSynced?: Date | string | null;
@@ -253,8 +253,8 @@ function SortableRow({ book, index, imageErrors, onImageError, onRemoveBook, isD
 
       {/* Date Added */}
       <td className="px-4 py-3 text-[var(--foreground)]/80 text-sm">
-        {book.dateAddedToShelf
-          ? format(new Date(book.dateAddedToShelf), "MMM dd, yyyy")
+        {book.addedAt
+          ? format(new Date(book.addedAt), "MMM dd, yyyy")
           : book.addedToLibrary
           ? format(new Date(book.addedToLibrary), "MMM dd, yyyy")
           : "-"}


### PR DESCRIPTION
## Summary
- Fixed "Date Added" column on shelf detail pages not sorting correctly
- Components were looking for `dateAddedToShelf` field that didn't exist in the data
- Changed to use `addedAt` which is correctly returned from `bookShelves.addedAt` by the repository

## Test plan
- [ ] Navigate to `/shelves/:id`
- [ ] Click "Date Added" column header
- [ ] Verify dates sort correctly (oldest first when ascending, newest first when descending)
- [ ] Toggle direction and verify it reverses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)