### PR TITLE
fix: add iOS safe area support to bottom sheets

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -30,6 +30,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  viewportFit: "cover", // Required for safe-area-inset-* to work on iOS
 };
 
 export default function RootLayout({

--- a/components/BookDetail/ShelfEditor.tsx
+++ b/components/BookDetail/ShelfEditor.tsx
@@ -238,20 +238,6 @@ export default function ShelfEditor({
     </>
   );
 
-  // Mobile wrapper (fixed at bottom)
-  const mobileButtons = buttons && (
-    <div className="fixed bottom-0 left-0 right-0 bg-[var(--card-bg)] border-t border-[var(--border-color)] p-4 flex gap-3 justify-end z-10">
-      {buttons}
-    </div>
-  );
-
-  // Desktop wrapper (relative positioning)
-  const desktopButtons = buttons && (
-    <div className="mt-6 pt-4 border-t border-[var(--border-color)] flex gap-3 justify-end">
-      {buttons}
-    </div>
-  );
-
   // Mobile: Use BottomSheet
   if (isMobile) {
     return (
@@ -262,6 +248,7 @@ export default function ShelfEditor({
         icon={<FolderOpen className="w-5 h-5" />}
         size="full"
         allowBackdropClose={!saving}
+        actions={buttons}
       >
         {/* Book Title and Summary */}
         <div className="mb-4">
@@ -272,10 +259,7 @@ export default function ShelfEditor({
             {summaryText}
           </p>
         </div>
-        <div className="mb-20">
-          {shelfContent}
-        </div>
-        {mobileButtons}
+        {shelfContent}
       </BottomSheet>
     );
   }
@@ -321,7 +305,7 @@ export default function ShelfEditor({
         </div>
 
         {/* Action Buttons - Fixed at bottom */}
-        {desktopButtons && (
+        {buttons && (
           <div className="p-6 pt-4 border-t border-[var(--border-color)] flex gap-3 justify-end flex-shrink-0">
             {buttons}
           </div>

--- a/components/Layout/BottomSheet.tsx
+++ b/components/Layout/BottomSheet.tsx
@@ -11,6 +11,7 @@ interface BottomSheetProps {
   icon?: React.ReactNode;
   size?: "small" | "medium" | "default" | "large" | "full";
   allowBackdropClose?: boolean;
+  actions?: React.ReactNode;
 }
 
 // Animation timing
@@ -32,6 +33,7 @@ export function BottomSheet({
   icon, 
   size = "default",
   allowBackdropClose = true,
+  actions,
 }: BottomSheetProps) {
   // Animation states: null = not rendered, 'entering' = animating in, 'entered' = visible, 'exiting' = animating out
   const [animationState, setAnimationState] = useState<'entering' | 'entered' | 'exiting' | null>(null);
@@ -108,7 +110,7 @@ export function BottomSheet({
       {/* Bottom Sheet */}
       <div 
         ref={contentRef}
-        className={`fixed bottom-0 left-0 right-0 z-[101] bg-[var(--card-bg)] border-t border-[var(--border-color)] shadow-2xl flex flex-col ${
+        className={`fixed bottom-0 left-0 right-0 z-[101] bg-[var(--card-bg)] border-t border-[var(--border-color)] shadow-2xl flex flex-col pb-safe ${
           sizeClasses[size]
         }`}
         style={{
@@ -141,6 +143,13 @@ export function BottomSheet({
         <div className="flex-1 overflow-y-auto p-4">
           {children}
         </div>
+
+        {/* Optional action buttons */}
+        {actions && (
+          <div className="flex-shrink-0 border-t border-[var(--border-color)] p-4 bg-[var(--card-bg)] flex gap-3 justify-end">
+            {actions}
+          </div>
+        )}
       </div>
     </>
   );

--- a/components/ShelfManagement/AddBooksToShelfModal.tsx
+++ b/components/ShelfManagement/AddBooksToShelfModal.tsx
@@ -319,44 +319,42 @@ export function AddBooksToShelfModal({
         icon={<LibraryIcon className="w-5 h-5" />}
         size="full"
         allowBackdropClose={false}
+        actions={
+          <>
+            <button
+              onClick={handleClose}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--hover-bg)] rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={selectedBookIds.size === 0 || submitting}
+              className="px-4 py-2 text-sm font-medium bg-[var(--accent)] text-white rounded-md hover:bg-[var(--light-accent)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting 
+                ? "Adding..." 
+                : `Add ${selectedBookIds.size || ""} ${selectedBookIds.size === 1 ? "Book" : "Books"}`
+              }
+            </button>
+          </>
+        }
       >
-        <div className="pb-20">
-          {/* Subtitle */}
-          <div className="mb-4">
-            <p className="text-sm text-[var(--foreground)]/70 mb-3">
-              {shelfName}
+        {/* Subtitle */}
+        <div className="mb-4">
+          <p className="text-sm text-[var(--foreground)]/70 mb-3">
+            {shelfName}
+          </p>
+          {selectedBookIds.size > 0 && (
+            <p className="text-sm text-[var(--foreground)]/70">
+              {selectedBookIds.size} {selectedBookIds.size === 1 ? "book" : "books"} selected
             </p>
-            {selectedBookIds.size > 0 && (
-              <p className="text-sm text-[var(--foreground)]/70">
-                {selectedBookIds.size} {selectedBookIds.size === 1 ? "book" : "books"} selected
-              </p>
-            )}
-          </div>
-
-          {/* Content */}
-          {searchAndResults}
+          )}
         </div>
 
-        {/* Fixed bottom buttons */}
-        <div className="fixed bottom-0 left-0 right-0 bg-[var(--card-bg)] border-t border-[var(--border-color)] p-4 flex gap-3 justify-end shadow-[0_-4px_12px_rgba(0,0,0,0.1)]">
-          <button
-            onClick={handleClose}
-            disabled={submitting}
-            className="px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--hover-bg)] rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={selectedBookIds.size === 0 || submitting}
-            className="px-4 py-2 text-sm font-medium bg-[var(--accent)] text-white rounded-md hover:bg-[var(--light-accent)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting 
-              ? "Adding..." 
-              : `Add ${selectedBookIds.size || ""} ${selectedBookIds.size === 1 ? "Book" : "Books"}`
-            }
-          </button>
-        </div>
+        {/* Content */}
+        {searchAndResults}
       </BottomSheet>
     );
   }

--- a/components/ShelfManagement/CreateShelfModal.tsx
+++ b/components/ShelfManagement/CreateShelfModal.tsx
@@ -156,18 +156,12 @@ export function CreateShelfModal({
         icon={<FolderPlus className="w-5 h-5" />}
         size="full"
         allowBackdropClose={false}
+        actions={actionButtons}
       >
-        <div className="pb-20">
-          <p className="text-sm text-[var(--subheading-text)] mb-4">
-            Organize your books into custom shelves
-          </p>
-          {formContent}
-        </div>
-
-        {/* Fixed bottom buttons */}
-        <div className="fixed bottom-0 left-0 right-0 bg-[var(--card-bg)] border-t border-[var(--border-color)] p-4 flex gap-3 justify-end shadow-[0_-4px_12px_rgba(0,0,0,0.1)]">
-          {actionButtons}
-        </div>
+        <p className="text-sm text-[var(--subheading-text)] mb-4">
+          Organize your books into custom shelves
+        </p>
+        {formContent}
       </BottomSheet>
     );
   }

--- a/components/ShelfManagement/EditShelfModal.tsx
+++ b/components/ShelfManagement/EditShelfModal.tsx
@@ -161,18 +161,12 @@ export function EditShelfModal({
         icon={<FolderEdit className="w-5 h-5" />}
         size="full"
         allowBackdropClose={false}
+        actions={actionButtons}
       >
-        <div className="pb-20">
-          <p className="text-sm text-[var(--subheading-text)] mb-4">
-            Update your shelf details
-          </p>
-          {formContent}
-        </div>
-
-        {/* Fixed bottom buttons */}
-        <div className="fixed bottom-0 left-0 right-0 bg-[var(--card-bg)] border-t border-[var(--border-color)] p-4 flex gap-3 justify-end shadow-[0_-4px_12px_rgba(0,0,0,0.1)]">
-          {actionButtons}
-        </div>
+        <p className="text-sm text-[var(--subheading-text)] mb-4">
+          Update your shelf details
+        </p>
+        {formContent}
       </BottomSheet>
     );
   }

--- a/components/ShelfManagement/ShelfSelectionModal.tsx
+++ b/components/ShelfManagement/ShelfSelectionModal.tsx
@@ -324,6 +324,24 @@ export function ShelfSelectionModal({
         icon={<LibraryIcon className="w-5 h-5" />}
         size="full"
         allowBackdropClose={false}
+        actions={
+          <>
+            <button
+              onClick={handleClose}
+              disabled={submitting}
+              className="px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--hover-bg)] rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSubmit}
+              disabled={selectedShelfId === null || submitting}
+              className="px-4 py-2 text-sm font-medium bg-[var(--accent)] text-white rounded-md hover:bg-[var(--light-accent)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? "Processing..." : confirmButtonText}
+            </button>
+          </>
+        }
       >
         {/* Subtitle */}
         <div className="mb-4">
@@ -333,27 +351,7 @@ export function ShelfSelectionModal({
         </div>
 
         {/* Content */}
-        <div className="mb-20">
-          {searchAndResults}
-        </div>
-
-        {/* Fixed bottom buttons */}
-        <div className="fixed bottom-0 left-0 right-0 bg-[var(--card-bg)] border-t border-[var(--border-color)] p-4 flex gap-3 justify-end z-10">
-          <button
-            onClick={handleClose}
-            disabled={submitting}
-            className="px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--hover-bg)] rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleSubmit}
-            disabled={selectedShelfId === null || submitting}
-            className="px-4 py-2 text-sm font-medium bg-[var(--accent)] text-white rounded-md hover:bg-[var(--light-accent)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {submitting ? "Processing..." : confirmButtonText}
-          </button>
-        </div>
+        {searchAndResults}
       </BottomSheet>
     );
   }


### PR DESCRIPTION
## Summary
Adds iOS safe area support to bottom sheets and action buttons to prevent accidental activation of iOS home indicator and Siri touch bar.

## Changes
- **Added `viewportFit: 'cover'`** to viewport config to enable `env(safe-area-inset-bottom)` on iOS
- **Enhanced BottomSheet component** with optional `actions` prop and `pb-safe` class
- **Refactored 5 modals** to use new BottomSheet actions prop instead of position:fixed hacks
  - CreateShelfModal
  - EditShelfModal
  - ShelfSelectionModal
  - AddBooksToShelfModal
  - ShelfEditor
- **Removed manual spacers** (`pb-20`, `mb-20`) and fixed positioning patterns
- **Action buttons now properly contained** within BottomSheet with automatic safe area padding

## Benefits
- ✅ Adequate touch space clearance on iOS devices with home indicator
- ✅ Cleaner architecture - no more position:fixed escaping boundaries
- ✅ Consistent pattern matching BaseModal's `actions` prop
- ✅ Centralized safe area handling in one place
- ✅ Net -22 lines of code (cleaner!)

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ All 7 files modified successfully
- ⏳ Manual testing on iOS device needed

## Visual Reference
See original issue image showing action buttons too close to bottom edge.