### PR TITLE
Move Log Progress modal submit button to action bar

### DIFF
--- a/components/BookDetail/BookProgress.tsx
+++ b/components/BookDetail/BookProgress.tsx
@@ -31,6 +31,8 @@ interface BookProgressProps {
   setShowProgressModeDropdown: (show: boolean) => void;
   progressModeDropdownRef?: React.RefObject<HTMLDivElement | null>;
   showHeader?: boolean;
+  showSubmitButton?: boolean;
+  formId?: string;
 }
 
 export default function BookProgress({
@@ -51,6 +53,8 @@ export default function BookProgress({
   setShowProgressModeDropdown,
   progressModeDropdownRef,
   showHeader = true,
+  showSubmitButton = true,
+  formId,
 }: BookProgressProps) {
   const progressPercentage = book.latestProgress?.currentPercentage || 0;
   const editorRef = useRef<MDXEditorMethods>(null);
@@ -69,7 +73,7 @@ export default function BookProgress({
           Log Progress
         </h2>
       )}
-      <form onSubmit={onSubmit} className="space-y-4">
+      <form id={formId} onSubmit={onSubmit} className="space-y-4">
             <div className="flex flex-col md:flex-row gap-4">
               <div className="flex-1">
                 <label className="block text-xs uppercase tracking-wide text-[var(--foreground)]/60 mb-2 font-semibold">
@@ -187,13 +191,15 @@ export default function BookProgress({
               />
             </div>
 
-            <button
-              type="submit"
-              className="w-full px-6 py-3 bg-[var(--accent)] text-white rounded-lg font-semibold hover:bg-[var(--light-accent)] transition-colors flex items-center justify-center gap-2"
-            >
-              <TrendingUp className="w-5 h-5" />
-              Log Progress
-            </button>
+            {showSubmitButton && (
+              <button
+                type="submit"
+                className="w-full px-6 py-3 bg-[var(--accent)] text-white rounded-lg font-semibold hover:bg-[var(--light-accent)] transition-colors flex items-center justify-center gap-2"
+              >
+                <TrendingUp className="w-5 h-5" />
+                Log Progress
+              </button>
+            )}
           </form>
     </div>
   );

--- a/components/Modals/LogProgressModal.tsx
+++ b/components/Modals/LogProgressModal.tsx
@@ -198,8 +198,30 @@ export default function LogProgressModal({
         setShowProgressModeDropdown={setShowProgressModeDropdown}
         progressModeDropdownRef={progressModeDropdownRef}
         showHeader={false}
+        showSubmitButton={false}
+        formId="log-progress-form"
       />
     </div>
+  );
+
+  const actionButtons = (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        className="px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--hover-bg)] rounded-lg transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        form="log-progress-form"
+        className="px-4 py-2 text-sm font-medium bg-[var(--accent)] text-white rounded-md hover:bg-[var(--light-accent)] transition-colors flex items-center gap-2"
+      >
+        <TrendingUp className="w-5 h-5" />
+        Log Progress
+      </button>
+    </>
   );
 
   // Use BottomSheet for mobile, BaseModal for desktop
@@ -212,6 +234,7 @@ export default function LogProgressModal({
           title={book.title}
           icon={<TrendingUp className="w-5 h-5" />}
           size="default"
+          actions={actionButtons}
         >
           {progressForm}
         </BottomSheet>
@@ -235,7 +258,7 @@ export default function LogProgressModal({
         isOpen={isOpen}
         onClose={onClose}
         title={`Log Progress - ${book.title}`}
-        actions={<></>}
+        actions={actionButtons}
         size="2xl"
         allowBackdropClose={false}
       >


### PR DESCRIPTION
## Summary

Fixes the Log Progress modal by moving the submit button from inside the form content to the modal's action bar, and adds a standard Cancel button. This follows the established modal pattern used throughout the app and eliminates the confusing "empty action bar" appearance.

## Changes

### BookProgress Component
- Added `showSubmitButton` prop (default: `true`) to conditionally render the inline submit button
- Added `formId` prop to allow external submit buttons to reference the form
- Maintains backward compatibility - existing usage in book detail page continues to work

### LogProgressModal Component
- Created `actionButtons` section with Cancel and Log Progress buttons
- Cancel button uses standard styling consistent with PageCountEditModal and other modals
- Log Progress button includes TrendingUp icon and primary action styling
- Removed confusing empty `actions={<></>}` fragment
- Applied to both desktop (BaseModal) and mobile (BottomSheet) views

## Benefits

- ✅ Follows standard modal UX pattern (content + action bar)
- ✅ Consistent styling with other modals in the app
- ✅ Clear Cancel option for users
- ✅ No more confusing "empty action bar"
- ✅ Works on both desktop and mobile
- ✅ All 3411 tests passing
- ✅ Backward compatible

## Testing

- All existing tests pass (3411 tests across 162 test files)
- No breaking changes to existing functionality