### PR TITLE
Add session deletion feature with confirmation modal

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,6 @@
 # Tome Constitution
 
-**Version**: | 1.0.0 | **Ratified**: 2025-11-24
+**Version**: | 1.1.0 | **Ratified**: 2025-11-24 | **Last Amended**: 2026-02-02
 
 ---
 
@@ -116,8 +116,8 @@ These constraints define Tome's identity. Violating them means building a differ
 4. **Zero External Service Dependencies**
    Tome must run in complete isolation. No Redis, no cloud APIs, no message queues.
 
-5. **Reading History is Never Deleted**
-   Sessions can be archived, hidden, or marked inactive—but never destroyed.
+5. **Reading History Preservation**
+   Reading history is durable and permanent. Sessions can be archived, hidden, or marked inactive by the system. Users may permanently delete sessions via explicit action with confirmation, but deletion is never automatic or implicit.
 
 ---
 
@@ -194,6 +194,12 @@ Constitution follows semantic versioning:
 ---
 
 ## Change Log
+
+**v1.1.0** (2026-02-02)
+- MINOR: Amended Non-Negotiable #5 to allow explicit user-initiated session deletion with confirmation
+- Rationale: Users need ability to remove incorrect or mistakenly created sessions
+- Impact: Added DELETE endpoint for sessions with confirmation modal in UI
+- Migration: No schema changes; deletion uses existing CASCADE foreign keys
 
 **v1.0.0** (2025-11-24)
 Initial constitution ratified with five core principles.

--- a/__tests__/e2e/api/sessions/session-delete.test.ts
+++ b/__tests__/e2e/api/sessions/session-delete.test.ts
@@ -1,0 +1,346 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { DELETE } from "@/app/api/books/[id]/sessions/[sessionId]/route";
+import { bookRepository, sessionRepository, progressRepository } from "@/lib/repositories";
+import { setupTestDatabase, teardownTestDatabase, clearTestDatabase } from "@/__tests__/helpers/db-setup";
+import { createMockRequest } from "@/__tests__/fixtures/test-data";
+import type { NextRequest } from "next/server";
+
+beforeAll(async () => {
+  await setupTestDatabase(__filename);
+});
+
+afterAll(async () => {
+  await teardownTestDatabase(__filename);
+});
+
+beforeEach(async () => {
+  await clearTestDatabase(__filename);
+});
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
+/**
+ * Helper to create a test book
+ */
+async function createTestBook(calibreId: number, title: string) {
+  return await bookRepository.create({
+    calibreId,
+    title,
+    authors: ["Test Author"],
+    path: `/test/path/${calibreId}`,
+    totalPages: 300,
+  });
+}
+
+/**
+ * Helper to create a test session
+ */
+async function createTestSession(bookId: number, overrides = {}) {
+  return await sessionRepository.create({
+    bookId,
+    sessionNumber: 1,
+    status: "to-read",
+    isActive: true,
+    ...overrides,
+  });
+}
+
+/**
+ * Helper to create a progress log
+ */
+async function createTestProgress(bookId: number, sessionId: number, overrides = {}) {
+  return await progressRepository.create({
+    bookId,
+    sessionId,
+    currentPage: 100,
+    currentPercentage: 33,
+    progressDate: "2025-01-15",
+    pagesRead: 100,
+    ...overrides,
+  });
+}
+
+/**
+ * Helper to make DELETE request
+ */
+function makeDeleteRequest(bookId: number, sessionId: number) {
+  const request = createMockRequest("DELETE", `http://localhost:3000/api/books/${bookId}/sessions/${sessionId}`);
+  return DELETE(request as NextRequest, {
+    params: Promise.resolve({ id: String(bookId), sessionId: String(sessionId) }),
+  });
+}
+
+// ============================================================================
+// TESTS: DELETE /api/books/[id]/sessions/[sessionId]
+// ============================================================================
+
+describe("DELETE /api/books/[id]/sessions/[sessionId]", () => {
+  describe("Success Cases", () => {
+    test("should delete archived session and return metadata", async () => {
+      // Create book and archived session
+      const book = await createTestBook(1, "Test Book");
+      const session = await createTestSession(book.id, {
+        sessionNumber: 1,
+        status: "read",
+        isActive: false,
+        startedDate: "2025-01-01",
+        completedDate: "2025-01-15",
+      });
+
+      // Add progress logs
+      await createTestProgress(book.id, session.id, {
+        currentPage: 100,
+        currentPercentage: 33,
+        progressDate: "2025-01-05",
+      });
+      await createTestProgress(book.id, session.id, {
+        currentPage: 300,
+        currentPercentage: 100,
+        progressDate: "2025-01-15",
+      });
+
+      // Delete session
+      const response = await makeDeleteRequest(book.id, session.id);
+      const data = await response.json();
+
+      // Verify response
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        deletedSessionNumber: 1,
+        wasActive: false,
+        newSessionCreated: false,
+      });
+
+      // Verify session is deleted
+      const deletedSession = await sessionRepository.findById(session.id);
+      expect(deletedSession).toBeUndefined();
+
+      // Verify progress logs are deleted (cascade)
+      const progressLogs = await progressRepository.findBySessionId(session.id);
+      expect(progressLogs.length).toBe(0);
+
+      // Verify no new session was created
+      const allSessions = await sessionRepository.findAllByBookId(book.id);
+      expect(allSessions.length).toBe(0);
+    });
+
+    test("should delete active session, create new to-read session, and return metadata", async () => {
+      // Create book and active session
+      const book = await createTestBook(2, "Active Book");
+      const session = await createTestSession(book.id, {
+        sessionNumber: 1,
+        status: "reading",
+        isActive: true,
+        startedDate: "2025-02-01",
+      });
+
+      // Add progress log
+      await createTestProgress(book.id, session.id, {
+        currentPage: 150,
+        currentPercentage: 50,
+        progressDate: "2025-02-01",
+      });
+
+      // Delete session
+      const response = await makeDeleteRequest(book.id, session.id);
+      const data = await response.json();
+
+      // Verify response
+      expect(response.status).toBe(200);
+      expect(data).toEqual({
+        deletedSessionNumber: 1,
+        wasActive: true,
+        newSessionCreated: true,
+      });
+
+      // Verify original session is deleted
+      const deletedSession = await sessionRepository.findById(session.id);
+      expect(deletedSession).toBeUndefined();
+
+      // Verify progress logs are deleted (cascade)
+      const progressLogs = await progressRepository.findBySessionId(session.id);
+      expect(progressLogs.length).toBe(0);
+
+      // Verify new to-read session was created
+      const newSession = await sessionRepository.findActiveByBookId(book.id);
+      expect(newSession).toBeDefined();
+      expect(newSession!.status).toBe("to-read");
+      expect(newSession!.sessionNumber).toBe(1);
+      expect(newSession!.isActive).toBe(true);
+    });
+
+    test("should preserve other sessions when deleting middle session", async () => {
+      // Create book with 3 sessions
+      const book = await createTestBook(3, "Multi-Session Book");
+      
+      const session1 = await createTestSession(book.id, {
+        sessionNumber: 1,
+        status: "read",
+        isActive: false,
+        completedDate: "2024-01-01",
+      });
+
+      const session2 = await createTestSession(book.id, {
+        sessionNumber: 2,
+        status: "read",
+        isActive: false,
+        completedDate: "2024-06-01",
+      });
+
+      const session3 = await createTestSession(book.id, {
+        sessionNumber: 3,
+        status: "reading",
+        isActive: true,
+        startedDate: "2025-01-01",
+      });
+
+      // Delete middle session
+      const response = await makeDeleteRequest(book.id, session2.id);
+      const data = await response.json();
+
+      // Verify response
+      expect(response.status).toBe(200);
+      expect(data.deletedSessionNumber).toBe(2);
+
+      // Verify session2 is deleted
+      const deletedSession = await sessionRepository.findById(session2.id);
+      expect(deletedSession).toBeUndefined();
+
+      // Verify other sessions remain
+      const remainingSessions = await sessionRepository.findAllByBookId(book.id);
+      expect(remainingSessions.length).toBe(2);
+
+      const sessionNumbers = remainingSessions.map(s => s.sessionNumber).sort();
+      expect(sessionNumbers).toEqual([1, 3]); // Session 2 deleted, 1 and 3 remain
+    });
+  });
+
+  describe("Error Cases", () => {
+    test("should return 404 when session not found", async () => {
+      const book = await createTestBook(4, "Test Book");
+
+      const response = await makeDeleteRequest(book.id, 999);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.error).toContain("Session not found");
+    });
+
+    test("should return 404 when session belongs to different book", async () => {
+      // Create two books
+      const book1 = await createTestBook(5, "Book 1");
+      const book2 = await createTestBook(6, "Book 2");
+
+      // Create session for book1
+      const session = await createTestSession(book1.id, {
+        sessionNumber: 1,
+        status: "to-read",
+        isActive: true,
+      });
+
+      // Try to delete using book2's ID
+      const response = await makeDeleteRequest(book2.id, session.id);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain("Session does not belong to specified book");
+    });
+
+    test("should return 400 when bookId is invalid", async () => {
+      const response = await makeDeleteRequest(NaN, 1);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain("Invalid book ID or session ID");
+    });
+
+    test("should return 400 when sessionId is invalid", async () => {
+      const book = await createTestBook(7, "Test Book");
+      const response = await makeDeleteRequest(book.id, NaN);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toContain("Invalid book ID or session ID");
+    });
+  });
+
+  describe("Cascade Delete", () => {
+    test("should cascade delete progress logs when session is deleted", async () => {
+      // Create book and session with multiple progress logs
+      const book = await createTestBook(8, "Book with Progress");
+      const session = await createTestSession(book.id, {
+        sessionNumber: 1,
+        status: "reading",
+        isActive: true,
+        startedDate: "2025-01-01",
+      });
+
+      // Create 5 progress logs
+      for (let i = 1; i <= 5; i++) {
+        await createTestProgress(book.id, session.id, {
+          currentPage: i * 50,
+          currentPercentage: (i * 50 / 300) * 100,
+          progressDate: `2025-01-${String(i).padStart(2, '0')}`,
+        });
+      }
+
+      // Verify progress logs exist
+      const progressBeforeDelete = await progressRepository.findBySessionId(session.id);
+      expect(progressBeforeDelete.length).toBe(5);
+
+      // Delete session
+      const response = await makeDeleteRequest(book.id, session.id);
+      expect(response.status).toBe(200);
+
+      // Verify all progress logs are deleted
+      const progressAfterDelete = await progressRepository.findBySessionId(session.id);
+      expect(progressAfterDelete.length).toBe(0);
+    });
+
+    test("should only delete progress logs for the deleted session", async () => {
+      // Create book with 2 sessions
+      const book = await createTestBook(9, "Book with Multiple Sessions");
+      
+      const session1 = await createTestSession(book.id, {
+        sessionNumber: 1,
+        status: "read",
+        isActive: false,
+        completedDate: "2024-12-31",
+      });
+
+      const session2 = await createTestSession(book.id, {
+        sessionNumber: 2,
+        status: "reading",
+        isActive: true,
+        startedDate: "2025-01-01",
+      });
+
+      // Add progress to both sessions
+      await createTestProgress(book.id, session1.id, {
+        currentPage: 300,
+        currentPercentage: 100,
+        progressDate: "2024-12-31",
+      });
+
+      await createTestProgress(book.id, session2.id, {
+        currentPage: 150,
+        currentPercentage: 50,
+        progressDate: "2025-01-15",
+      });
+
+      // Delete session1
+      const response = await makeDeleteRequest(book.id, session1.id);
+      expect(response.status).toBe(200);
+
+      // Verify session1 progress is deleted
+      const session1Progress = await progressRepository.findBySessionId(session1.id);
+      expect(session1Progress.length).toBe(0);
+
+      // Verify session2 progress still exists
+      const session2Progress = await progressRepository.findBySessionId(session2.id);
+      expect(session2Progress.length).toBe(1);
+    });
+  });
+});

--- a/__tests__/integration/services/session.service.delete.test.ts
+++ b/__tests__/integration/services/session.service.delete.test.ts
@@ -1,0 +1,225 @@
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import { setupTestDatabase, clearTestDatabase, teardownTestDatabase, type TestDatabaseInstance } from "@/__tests__/helpers/db-setup";
+import { bookRepository, sessionRepository, progressRepository } from "@/lib/repositories";
+import { sessionService } from "@/lib/services/session.service";
+
+const TEST_FILE_PATH = __filename;
+let testDbInstance: TestDatabaseInstance;
+
+beforeAll(async () => {
+  testDbInstance = await setupTestDatabase(TEST_FILE_PATH);
+});
+
+beforeEach(async () => {
+  await clearTestDatabase(testDbInstance);
+});
+
+afterAll(async () => {
+  await teardownTestDatabase(testDbInstance);
+});
+
+test("deleteSession - should delete archived session without creating new session", async () => {
+  // Create book
+  const book = await bookRepository.create({
+    calibreId: 1,
+    title: "Test Book",
+    authors: ["Test Author"],
+    path: "/test/path",
+    totalPages: 300,
+  });
+
+  // Create archived session with progress
+  const session = await sessionRepository.create({
+    bookId: book.id,
+    sessionNumber: 1,
+    status: "read",
+    isActive: false,
+    startedDate: "2025-01-01",
+    completedDate: "2025-01-15",
+  });
+
+  // Add progress logs
+  await progressRepository.create({
+    bookId: book.id,
+    sessionId: session.id,
+    currentPage: 100,
+    currentPercentage: 33,
+    progressDate: "2025-01-05",
+    pagesRead: 100,
+  });
+
+  await progressRepository.create({
+    bookId: book.id,
+    sessionId: session.id,
+    currentPage: 300,
+    currentPercentage: 100,
+    progressDate: "2025-01-15",
+    pagesRead: 200,
+  });
+
+  // Delete session
+  const result = await sessionService.deleteSession(book.id, session.id);
+
+  // Verify result
+  expect(result.deletedSessionNumber).toBe(1);
+  expect(result.wasActive).toBe(false);
+  expect(result.newSessionCreated).toBe(false);
+
+  // Verify session is deleted
+  const deletedSession = await sessionRepository.findById(session.id);
+  expect(deletedSession).toBeUndefined();
+
+  // Verify progress logs are deleted (cascade)
+  const progressLogs = await progressRepository.findBySessionId(session.id);
+  expect(progressLogs.length).toBe(0);
+
+  // Verify no new session was created
+  const allSessions = await sessionRepository.findAllByBookId(book.id);
+  expect(allSessions.length).toBe(0);
+});
+
+test("deleteSession - should delete active session and create new to-read session", async () => {
+  // Create book
+  const book = await bookRepository.create({
+    calibreId: 2,
+    title: "Active Book",
+    authors: ["Test Author"],
+    path: "/test/path2",
+    totalPages: 400,
+  });
+
+  // Create active session with progress
+  const session = await sessionRepository.create({
+    bookId: book.id,
+    sessionNumber: 1,
+    status: "reading",
+    isActive: true,
+    startedDate: "2025-02-01",
+  });
+
+  // Add progress log
+  await progressRepository.create({
+    bookId: book.id,
+    sessionId: session.id,
+    currentPage: 150,
+    currentPercentage: 37.5,
+    progressDate: "2025-02-01",
+    pagesRead: 150,
+  });
+
+  // Delete session
+  const result = await sessionService.deleteSession(book.id, session.id);
+
+  // Verify result
+  expect(result.deletedSessionNumber).toBe(1);
+  expect(result.wasActive).toBe(true);
+  expect(result.newSessionCreated).toBe(true);
+
+  // Verify original session is deleted
+  const deletedSession = await sessionRepository.findById(session.id);
+  expect(deletedSession).toBeUndefined();
+
+  // Verify progress logs are deleted (cascade)
+  const progressLogs = await progressRepository.findBySessionId(session.id);
+  expect(progressLogs.length).toBe(0);
+
+  // Verify new to-read session was created
+  const newSession = await sessionRepository.findActiveByBookId(book.id);
+  expect(newSession).toBeDefined();
+  expect(newSession!.status).toBe("to-read");
+  expect(newSession!.sessionNumber).toBe(1);
+  expect(newSession!.isActive).toBe(true);
+});
+
+test("deleteSession - should throw error if session not found", async () => {
+  const book = await bookRepository.create({
+    calibreId: 3,
+    title: "Test Book",
+    authors: ["Test Author"],
+    path: "/test/path3",
+  });
+
+  await expect(
+    sessionService.deleteSession(book.id, 999)
+  ).rejects.toThrow("Session not found");
+});
+
+test("deleteSession - should throw error if bookId mismatch", async () => {
+  // Create two books
+  const book1 = await bookRepository.create({
+    calibreId: 4,
+    title: "Book 1",
+    authors: ["Author 1"],
+    path: "/path1",
+  });
+
+  const book2 = await bookRepository.create({
+    calibreId: 5,
+    title: "Book 2",
+    authors: ["Author 2"],
+    path: "/path2",
+  });
+
+  // Create session for book1
+  const session = await sessionRepository.create({
+    bookId: book1.id,
+    sessionNumber: 1,
+    status: "to-read",
+    isActive: true,
+  });
+
+  // Try to delete using book2's ID
+  await expect(
+    sessionService.deleteSession(book2.id, session.id)
+  ).rejects.toThrow("Session does not belong to specified book");
+});
+
+test("deleteSession - should handle multiple sessions correctly", async () => {
+  // Create book
+  const book = await bookRepository.create({
+    calibreId: 6,
+    title: "Multi-Session Book",
+    authors: ["Test Author"],
+    path: "/test/path6",
+    totalPages: 500,
+  });
+
+  // Create multiple sessions
+  const session1 = await sessionRepository.create({
+    bookId: book.id,
+    sessionNumber: 1,
+    status: "read",
+    isActive: false,
+    completedDate: "2024-01-01",
+  });
+
+  const session2 = await sessionRepository.create({
+    bookId: book.id,
+    sessionNumber: 2,
+    status: "read",
+    isActive: false,
+    completedDate: "2024-06-01",
+  });
+
+  const session3 = await sessionRepository.create({
+    bookId: book.id,
+    sessionNumber: 3,
+    status: "reading",
+    isActive: true,
+    startedDate: "2025-01-01",
+  });
+
+  // Delete middle session
+  await sessionService.deleteSession(book.id, session2.id);
+
+  // Verify session2 is deleted
+  const deletedSession = await sessionRepository.findById(session2.id);
+  expect(deletedSession).toBeUndefined();
+
+  // Verify other sessions remain
+  const remainingSessions = await sessionRepository.findAllByBookId(book.id);
+  expect(remainingSessions.length).toBe(2);
+  
+  const sessionNumbers = remainingSessions.map(s => s.sessionNumber).sort();
+  expect(sessionNumbers).toEqual([1, 3]); // Session 2 deleted, 1 and 3 remain
+});

--- a/app/api/books/[id]/sessions/[sessionId]/route.ts
+++ b/app/api/books/[id]/sessions/[sessionId]/route.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@/lib/logger";
 import { NextRequest, NextResponse } from "next/server";
 import { sessionRepository } from "@/lib/repositories";
+import { sessionService } from "@/lib/services/session.service";
 
 export const dynamic = 'force-dynamic';
 
@@ -116,6 +117,84 @@ export async function PATCH(
         error: "Failed to update session",
         details: error instanceof Error ? error.message : String(error)
       },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/books/:id/sessions/:sessionId
+ * Delete a reading session and all associated progress logs
+ * 
+ * If the session is active, a new "to-read" session will be created automatically.
+ * 
+ * Responses:
+ * - 200: Session deleted successfully (returns metadata)
+ * - 400: Invalid request (invalid IDs, bookId mismatch)
+ * - 404: Session not found
+ * - 500: Deletion failed
+ */
+export async function DELETE(
+  request: NextRequest,
+  props: { params: Promise<{ id: string; sessionId: string }> }
+) {
+  const params = await props.params;
+  const logger = getLogger().child({ route: "DELETE /api/books/[id]/sessions/[sessionId]" });
+
+  try {
+    // Parse and validate IDs
+    const bookId = parseInt(params.id);
+    const sessionId = parseInt(params.sessionId);
+
+    if (isNaN(bookId) || isNaN(sessionId)) {
+      logger.warn({ bookId: params.id, sessionId: params.sessionId }, "Invalid ID format");
+      return NextResponse.json(
+        { error: "Invalid book ID or session ID" },
+        { status: 400 }
+      );
+    }
+
+    logger.info({ bookId, sessionId }, "Deleting session");
+
+    // Delete session via service
+    const result = await sessionService.deleteSession(bookId, sessionId);
+
+    logger.info({
+      bookId,
+      sessionId,
+      deletedSessionNumber: result.deletedSessionNumber,
+      wasActive: result.wasActive,
+      newSessionCreated: result.newSessionCreated,
+    }, "Session deleted successfully");
+
+    return NextResponse.json(result);
+  } catch (error) {
+    const err = error as Error;
+    
+    // Handle specific error cases
+    if (err.message === "Session not found") {
+      logger.warn({ bookId: params.id, sessionId: params.sessionId }, "Session not found");
+      return NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 }
+      );
+    }
+
+    if (err.message === "Session does not belong to specified book") {
+      logger.warn({
+        bookId: params.id,
+        sessionId: params.sessionId,
+      }, "Session bookId mismatch");
+      return NextResponse.json(
+        { error: "Session does not belong to specified book" },
+        { status: 400 }
+      );
+    }
+
+    // Generic server error
+    logger.error({ err, bookId: params.id, sessionId: params.sessionId }, "Failed to delete session");
+    return NextResponse.json(
+      { error: "Failed to delete session" },
       { status: 500 }
     );
   }

--- a/components/CurrentlyReading/SessionActionsDropdown.tsx
+++ b/components/CurrentlyReading/SessionActionsDropdown.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+
+interface SessionActionsDropdownProps {
+  onEdit: () => void;
+  onDelete: () => void;
+  disabled?: boolean;
+}
+
+interface MenuPosition {
+  top: number;
+  left: number;
+}
+
+export function SessionActionsDropdown({
+  onEdit,
+  onDelete,
+  disabled = false,
+}: SessionActionsDropdownProps) {
+  const [showMenu, setShowMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition>({ top: 0, left: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const updateMenuPosition = useCallback(() => {
+    if (!buttonRef.current) return;
+
+    const rect = buttonRef.current.getBoundingClientRect();
+    const menuWidth = 192; // w-48 = 12rem = 192px
+
+    setMenuPosition({
+      top: rect.bottom + 4, // 4px gap below button
+      left: rect.right - menuWidth, // Align right edge with button
+    });
+  }, []);
+
+  // Update position when menu opens
+  useEffect(() => {
+    if (showMenu) {
+      updateMenuPosition();
+    }
+  }, [showMenu, updateMenuPosition]);
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    if (!showMenu) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as Node;
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(target)
+      ) {
+        setShowMenu(false);
+      }
+    }
+
+    function handleScroll() {
+      setShowMenu(false);
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    window.addEventListener("scroll", handleScroll, true);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [showMenu]);
+
+  const menuContent = showMenu && (
+    <div
+      ref={menuRef}
+      className="fixed w-48 bg-[var(--card-bg)] border border-[var(--border-color)] rounded-lg shadow-lg py-1 z-50"
+      style={{ top: menuPosition.top, left: menuPosition.left }}
+    >
+      <button
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onEdit();
+          setShowMenu(false);
+        }}
+        className="w-full px-4 py-2 text-left text-sm text-[var(--foreground)] hover:bg-[var(--hover-bg)] flex items-center gap-2"
+      >
+        <Pencil className="w-4 h-4" />
+        Edit Session
+      </button>
+
+      <button
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          onDelete();
+          setShowMenu(false);
+        }}
+        className="w-full px-4 py-2 text-left text-sm text-red-500 hover:bg-red-500/10 flex items-center gap-2"
+      >
+        <Trash2 className="w-4 h-4" />
+        Delete Session
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setShowMenu(!showMenu);
+        }}
+        disabled={disabled}
+        className="p-1.5 text-[var(--foreground)]/70 hover:text-[var(--foreground)] hover:bg-[var(--hover-bg)] rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        aria-label="Session actions"
+        title="Session actions"
+      >
+        <MoreVertical className="w-4 h-4" />
+      </button>
+
+      {typeof document !== "undefined" && createPortal(menuContent, document.body)}
+    </div>
+  );
+}

--- a/components/Modals/DeleteSessionModal.tsx
+++ b/components/Modals/DeleteSessionModal.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { X, Trash2 } from "lucide-react";
+import { Button } from "@/components/Utilities/Button";
+import { useState } from "react";
+
+interface DeleteSessionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  sessionNumber: number;
+  progressCount: number;
+  bookTitle: string;
+  isActive: boolean;
+}
+
+export default function DeleteSessionModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  sessionNumber,
+  progressCount,
+  bookTitle,
+  isActive,
+}: DeleteSessionModalProps) {
+  const [submitting, setSubmitting] = useState(false);
+
+  if (!isOpen) return null;
+
+  async function handleConfirm() {
+    setSubmitting(true);
+    try {
+      await onConfirm();
+      onClose();
+    } catch (error) {
+      // Error handling done by parent component (toast)
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-[var(--card-bg)] border border-[var(--border-color)] rounded-lg shadow-lg p-6 max-w-md w-full">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-red-500/10 rounded-lg">
+              <Trash2 className="w-6 h-6 text-red-600 dark:text-red-500" />
+            </div>
+            <div>
+              <h2 className="text-xl font-serif font-bold text-[var(--heading-text)]">
+                Delete Read #{sessionNumber}?
+              </h2>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-[var(--foreground)]/50 hover:text-[var(--foreground)] transition-colors"
+            aria-label="Close"
+            disabled={submitting}
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="mb-6">
+          <p className="text-lg italic font-bold font-serif text-[var(--heading-text)] mb-3">
+            {bookTitle}
+          </p>
+          <div className="text-sm text-[var(--subheading-text)] font-medium space-y-2">
+            <p className="font-semibold text-red-600 dark:text-red-500">
+              This will permanently delete:
+            </p>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>
+                {progressCount} progress {progressCount === 1 ? "log" : "logs"}
+              </li>
+              <li>All reading history for this session</li>
+              {isActive && (
+                <li className="text-[var(--foreground)]/80">
+                  A new "Want to Read" session will be created
+                </li>
+              )}
+            </ul>
+            <p className="font-semibold text-red-600 dark:text-red-500 pt-2">
+              This action cannot be undone.
+            </p>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex gap-3 justify-end">
+          <Button
+            variant="ghost"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={handleConfirm}
+            disabled={submitting}
+          >
+            {submitting ? "Deleting..." : "Delete Session"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements user-requested feature to delete reading sessions with confirmation modal. Users can now delete sessions from the Reading History tab via an ellipsis dropdown menu.

### Key Features
- **Delete archived sessions**: Permanently removes session and all progress logs
- **Delete active sessions**: Creates new "to-read" session after deletion to prevent orphaned books
- **Confirmation modal**: Red danger styling with progress count and warnings
- **Session numbering preserved**: Gaps allowed after deletion (maintains historical context)

### Changes
- **Backend**: DELETE endpoint at `/api/books/[id]/sessions/[sessionId]`
- **Service**: `deleteSession()` method in SessionService with cascade delete
- **Frontend**: DeleteSessionModal + SessionActionsDropdown components
- **UI Integration**: Ellipsis menu in ReadingHistoryTab (consistent with shelves page)
- **Tests**: 14 new tests (5 service + 9 E2E API) - all passing
- **Documentation**: Constitution amended to v1.1.0 to allow explicit deletion

### Key Design Decisions
- Active session deletion creates new "to-read" session (prevents orphaned books)
- Session numbers NOT renumbered after deletion (preserves context)
- Progress logs cascade delete via foreign key constraints
- Confirmation required with danger-styled modal
- Follows existing UI patterns (ellipsis dropdown from shelves page)

### Testing
- ✅ All 3425 tests passing (100% pass rate)
- ✅ Build succeeds without errors
- ✅ Manual API testing completed via curl
- ✅ Service integration tests (5/5 passing)
- ✅ E2E API tests (9/9 passing)

### Files Changed
- 8 files: 4 modified, 4 new
- +1,059 lines / -12 lines
- New components: DeleteSessionModal, SessionActionsDropdown
- Modified: SessionService, API route, ReadingHistoryTab, Constitution

### Documentation
See detailed implementation plan: `docs/plans/session-deletion.md`

### Constitutional Amendment
Updated Non-Negotiable #5 (v1.0.0 → v1.1.0):
- Changed from "Reading history is never deleted"
- To: "Reading history preservation with explicit user-initiated deletion allowed"
- Rationale: Users need ability to remove incorrect or mistakenly created sessions