### PR TITLE
fix: handle pre-2001 Unix timestamps in progress date migration

### DIFF
--- a/lib/migrations/0015_progress_dates_timezone.ts
+++ b/lib/migrations/0015_progress_dates_timezone.ts
@@ -41,7 +41,7 @@ const migration: CompanionMigration = {
     // Get all progress logs with INTEGER timestamps
     // Check both:
     // 1. typeof(progress_date) = 'integer' - values stored as INTEGER type
-    // 2. Numeric strings that look like Unix timestamps (> 1000000000)
+    // 2. Numeric strings that look like Unix timestamps (> 0)
     //    These can occur when Drizzle's table recreation copies INTEGER values
     //    into TEXT columns - SQLite stores them as TEXT type but they're still numbers
     const logs = db.prepare(`
@@ -49,7 +49,7 @@ const migration: CompanionMigration = {
       WHERE typeof(progress_date) = 'integer'
          OR (typeof(progress_date) = 'text' 
              AND CAST(progress_date AS INTEGER) = progress_date 
-             AND CAST(progress_date AS INTEGER) > 1000000000)
+             AND CAST(progress_date AS INTEGER) > 0)
     `).all() as Array<{ id: number; progress_date: number }>;
     
     logger.info({ count: logs.length }, "Found progress logs to convert");


### PR DESCRIPTION
## Summary

Fixes #336 - Stats page crashing with `RangeError: Invalid time value` for users with historical reading data from before 2001.

## Root Cause

The migration `0015_progress_dates_timezone.ts` used a threshold of Unix timestamp `1000000000` (Sept 9, 2001) to detect records needing conversion. This excluded 28 progress log entries from August 1996, leaving them as numeric strings like `"838944000"` instead of converting them to proper date strings like `"1996-08-02"`.

When the Stats page queried for recent progress with `WHERE progress_date >= '2026-01-05'`, lexicographic string comparison treated `"838944000" >= "2026-01-05"` as true (because '8' > '2'), including these malformed records. Parsing them as dates failed, causing the crash.

## Changes

- Changed threshold from `> 1000000000` to `> 0` in migration detection query (line 52)
- Updated comment to reflect the change (line 44)

## Testing

Tested with user @maxsmooth's pre-migration database:
- ✅ All 28 records from 1996-08-02 to 1996-08-29 converted correctly
- ✅ 0 unconverted timestamps remaining
- ✅ All 4,515 records properly formatted as YYYY-MM-DD
- ✅ Timezone conversion correct for Europe/Rome (UTC+2)

## Impact

Users with historical reading data from before Sept 9, 2001 will now have their progress logs converted correctly during migration, preventing Stats page crashes.