### PR TITLE
fix: resolve PR #381 Copilot review comments

### DIFF
--- a/__tests__/hooks/useDropdownPosition.test.ts
+++ b/__tests__/hooks/useDropdownPosition.test.ts
@@ -201,8 +201,8 @@ describe("useDropdownPosition", () => {
   });
 
   describe("Edge case: menu doesn't fit either way", () => {
-    test("should position below when more space below than above", () => {
-      // Button in lower-middle of viewport
+    test("should position above when more space above than below", () => {
+      // Button in lower-middle of viewport — more space above
       vi.spyOn(mockButtonElement, "getBoundingClientRect").mockReturnValue({
         top: 700,
         bottom: 740,
@@ -233,8 +233,8 @@ describe("useDropdownPosition", () => {
       expect(result.current.top).toBe(296);
     });
 
-    test("should position above when more space above than below", () => {
-      // Button in upper-middle of viewport
+    test("should position below when more space below than above", () => {
+      // Button in upper-middle of viewport — more space below
       vi.spyOn(mockButtonElement, "getBoundingClientRect").mockReturnValue({
         top: 250,
         bottom: 290,

--- a/hooks/useDropdownPosition.ts
+++ b/hooks/useDropdownPosition.ts
@@ -13,10 +13,11 @@ interface UseDropdownPositionOptions {
 }
 
 /**
- * Custom hook for intelligent dropdown menu positioning that prevents overflow.
+ * Custom hook for intelligent dropdown menu positioning that prevents viewport overflow.
  * 
  * Automatically positions the menu above or below the trigger button based on
- * available viewport space. Handles edge cases like initial render with zero
+ * available viewport space, and clamps the horizontal position so the menu
+ * stays within the viewport. Handles edge cases like initial render with zero
  * height and menus that don't fit in either direction.
  * 
  * @param buttonRef - Ref to the trigger button element
@@ -70,7 +71,7 @@ export function useDropdownPosition(
     if (menuHeight === 0) {
       setMenuPosition({
         top: rect.bottom + gap,
-        left: rect.right - resolvedMenuWidth,
+        left: Math.max(gap, Math.min(rect.right - resolvedMenuWidth, window.innerWidth - resolvedMenuWidth - gap)),
       });
       return;
     }
@@ -97,9 +98,12 @@ export function useDropdownPosition(
         : Math.max(gap, rect.top - menuHeight - gap);
     }
 
+    // Clamp horizontal position so the menu stays within the viewport
+    const left = Math.max(gap, Math.min(rect.right - resolvedMenuWidth, window.innerWidth - resolvedMenuWidth - gap));
+
     setMenuPosition({
       top,
-      left: rect.right - resolvedMenuWidth,
+      left,
     });
   }, [buttonRef, menuRef, menuWidth, gap]);
 

--- a/lib/services/shelf.service.ts
+++ b/lib/services/shelf.service.ts
@@ -489,6 +489,12 @@ export class ShelfService {
     logger.info({ shelfId, bookId }, "Book moved to top successfully");
   }
 
+  /**
+   * Move a book to the bottom of a shelf by sortOrder.
+   * Reorders by decrementing books above the current position and setting the
+   * target book to the maximum sortOrder. No-op when the book is already at
+   * the bottom.
+   */
   async moveBookToBottom(shelfId: number, bookId: number): Promise<void> {
     // Validate shelf exists
     const shelf = await shelfRepository.findById(shelfId);


### PR DESCRIPTION
Resolves Copilot review comments from PR #381.

### Changes
- **JSDoc**: Added documentation to `ShelfService.moveBookToBottom` to match `moveBookToTop` pattern
- **Performance**: Replaced O(n) `findIndex`/`find` per row with pre-computed `Map` lookup in read-next page (eliminates O(n^2) render cost)
- **Horizontal overflow**: Clamped dropdown `left` position within viewport bounds in `useDropdownPosition` hook
- **Test corrections**: Fixed swapped test names in `useDropdownPosition` edge case tests ("position above" vs "position below" were inverted)

### Notes
- Copilot comments 1 & 2 (optimistic update mismatch) were already resolved in the current code
- All 3894 tests pass, build succeeds