### PR TITLE
fix: correct isAtTop/isAtBottom logic in shelf page

### DIFF
--- a/app/shelves/[id]/page.tsx
+++ b/app/shelves/[id]/page.tsx
@@ -72,6 +72,15 @@ export default function ShelfDetailPage() {
   // Use shared book list view hook for filtering and selection
   const listView = useBookListView({ books });
 
+  // Calculate canonical shelf position (min/max sortOrder) for Move to Top/Bottom buttons
+  // This ensures buttons reflect actual shelf order, not filtered/sorted display order
+  const minSortOrder = books.length > 0 ? Math.min(...books.map(b => b.sortOrder ?? Infinity)) : Infinity;
+  const maxSortOrder = books.length > 0 ? Math.max(...books.map(b => b.sortOrder ?? -Infinity)) : -Infinity;
+
+  // Create lookup map for sortOrder (needed since listView.filteredBooks is typed as Book[])
+  // Mirrors pattern used in read-next page
+  const sortOrderLookup = new Map(books.map(b => [b.id, b.sortOrder ?? Infinity]));
+
   // Single book removal state
   const [removingBook, setRemovingBook] = useState<{ id: number; title: string } | null>(null);
   const [removeLoading, setRemoveLoading] = useState(false);
@@ -365,8 +374,8 @@ export default function ShelfDetailPage() {
                 <BookActionsDropdown
                   bookId={book.id}
                   bookTitle={book.title}
-                  isAtTop={book.id === books[0]?.id}
-                  isAtBottom={book.id === books[books.length - 1]?.id}
+                  isAtTop={sortOrderLookup.get(book.id) === minSortOrder}
+                  isAtBottom={sortOrderLookup.get(book.id) === maxSortOrder}
                   onRemove={() => setRemovingBook({ id: book.id, title: book.title })}
                   onMoveToTop={() => moveToTop(book.id)}
                   onMoveToBottom={() => moveToBottom(book.id)}
@@ -387,8 +396,8 @@ export default function ShelfDetailPage() {
                       <BookActionsDropdown
                         bookId={book.id}
                         bookTitle={book.title}
-                        isAtTop={book.id === books[0]?.id}
-                        isAtBottom={book.id === books[books.length - 1]?.id}
+                        isAtTop={sortOrderLookup.get(book.id) === minSortOrder}
+                        isAtBottom={sortOrderLookup.get(book.id) === maxSortOrder}
                         onRemove={() => setRemovingBook({ id: book.id, title: book.title })}
                         onMoveToTop={() => moveToTop(book.id)}
                         onMoveToBottom={() => moveToBottom(book.id)}
@@ -417,8 +426,8 @@ export default function ShelfDetailPage() {
                 <BookActionsDropdown
                   bookId={book.id}
                   bookTitle={book.title}
-                  isAtTop={book.id === books[0]?.id}
-                  isAtBottom={book.id === books[books.length - 1]?.id}
+                  isAtTop={sortOrderLookup.get(book.id) === minSortOrder}
+                  isAtBottom={sortOrderLookup.get(book.id) === maxSortOrder}
                   onRemove={() => setRemovingBook({ id: book.id, title: book.title })}
                   onMoveToTop={() => moveToTop(book.id)}
                   onMoveToBottom={() => moveToBottom(book.id)}
@@ -440,8 +449,8 @@ export default function ShelfDetailPage() {
                 <BookActionsDropdown
                   bookId={book.id}
                   bookTitle={book.title}
-                  isAtTop={book.id === books[0]?.id}
-                  isAtBottom={book.id === books[books.length - 1]?.id}
+                  isAtTop={sortOrderLookup.get(book.id) === minSortOrder}
+                  isAtBottom={sortOrderLookup.get(book.id) === maxSortOrder}
                   onRemove={() => setRemovingBook({ id: book.id, title: book.title })}
                   onMoveToTop={() => moveToTop(book.id)}
                   onMoveToBottom={() => moveToBottom(book.id)}


### PR DESCRIPTION
## Summary

Fixes incorrect Move to Top/Bottom button states in shelf pages when filtering or sorting is applied.

## Problem

In PR #381, GitHub Copilot identified that the shelf page was using **reference equality** (`book === books[0]`) to determine if a book is at the top/bottom of a shelf. This was updated to use ID-based comparison (`book.id === books[0]?.id`), but this still had a fundamental issue:

**The buttons were checking position in the filtered/sorted display view, not the canonical shelf order.**

### Example Issue

Consider a shelf with books having sortOrders [0, 1, 2, 3, 4]:
- User sorts by title (alphabetically)
- Book with sortOrder=2 appears first in the display
- "Move to Top" button becomes disabled (incorrectly thinks it's already at top)
- But the book isn't actually at sortOrder=0 in the canonical shelf order

## Solution

Replace array position checks with **sortOrder-based comparison** using a lookup map pattern:

1. **Calculate canonical position** from all books' sortOrder values:
   ```tsx
   const minSortOrder = Math.min(...books.map(b => b.sortOrder ?? Infinity));
   const maxSortOrder = Math.max(...books.map(b => b.sortOrder ?? -Infinity));
   ```

2. **Create lookup map** for O(1) access to each book's sortOrder:
   ```tsx
   const sortOrderLookup = new Map(books.map(b => [b.id, b.sortOrder ?? Infinity]));
   ```

3. **Compare against canonical position** instead of display position:
   ```tsx
   isAtTop={sortOrderLookup.get(book.id) === minSortOrder}
   isAtBottom={sortOrderLookup.get(book.id) === maxSortOrder}
   ```

### Why This Works

- Move to Top/Bottom operations always work with **canonical shelf order** (sortOrder field)
- The buttons now check against **canonical position**, matching the operation behavior
- Filtering/sorting only affects display, not the underlying shelf order
- Buttons remain semantically correct regardless of current view settings

## Benefits

- ✅ Buttons reflect **actual shelf position** (sortOrder), not display position
- ✅ Correct behavior regardless of filtering/sorting
- ✅ Type-safe (avoids runtime property access issues)
- ✅ O(1) lookups after initial map creation
- ✅ Mirrors pattern used in `/read-next` page
- ✅ Semantically consistent with Move operations

## Changes

**File:** `app/shelves/[id]/page.tsx`

- Added canonical position calculation (minSortOrder/maxSortOrder)
- Created sortOrderLookup map for type-safe access
- Updated all 4 button locations to use canonical position checks:
  1. Mobile draggable list (line ~377-378)
  2. Mobile filtered list (line ~399-400)
  3. Desktop draggable table (line ~429-430)
  4. Desktop filtered table (line ~452-453)

## Testing

- ✅ All 3,894 tests pass
- ✅ Move to Top/Bottom buttons correctly disabled at extremes
- ✅ Buttons remain accurate when filtering/sorting applied
- ✅ Buttons now reflect canonical shelf order, not display order
- ✅ No performance regression (O(1) lookups)

## Related

- Addresses feedback from PR #381 review
- Uses lookup map pattern consistent with `app/read-next/page.tsx`
- Properly implements concept identified in original PR #381 discussion