### PR TITLE
Import total pages from calibre on sync

### DIFF
--- a/lib/db/calibre.ts
+++ b/lib/db/calibre.ts
@@ -71,6 +71,7 @@ export interface CalibreBook {
   has_cover: number;
   description: string | null;
   rating: number | null; // 1-5 stars (converted from Calibre's 0-10 scale)
+  total_pages: number | null;
 }
 
 export interface PaginationOptions {
@@ -111,6 +112,8 @@ export function getAllBooks(options?: PaginationOptions): CalibreBook[] {
 
   const hasSeries = hasSeriesColumn || hasSeriesLinkTable;
 
+  const hasPagesLinkTable = tableNames.includes("books_pages_link");
+
   const query = `
     SELECT
       b.id,
@@ -123,6 +126,7 @@ export function getAllBooks(options?: PaginationOptions): CalibreBook[] {
       GROUP_CONCAT(DISTINCT a.name) as authors,
       ${hasPublisher ? 'p.name' : 'NULL'} as publisher,
       ${hasSeries ? 's.name' : 'NULL'} as series,
+      ${hasPagesLinkTable ? "bpl.pages" : "NULL"} as total_pages,
       GROUP_CONCAT(DISTINCT i.val) as isbn,
       c.text as description,
       r.rating as rating
@@ -136,6 +140,7 @@ export function getAllBooks(options?: PaginationOptions): CalibreBook[] {
         ? 'LEFT JOIN books_series_link bsl ON b.id = bsl.book LEFT JOIN series s ON bsl.series = s.id'
         : ''
     }
+    ${hasPagesLinkTable ? 'LEFT JOIN books_pages_link bpl ON b.id = bpl.book' : ''}
     LEFT JOIN identifiers i ON b.id = i.book AND i.type = 'isbn'
     LEFT JOIN comments c ON b.id = c.book
     LEFT JOIN books_ratings_link brl ON b.id = brl.book
@@ -174,6 +179,8 @@ export function getBookById(id: number): CalibreBook | undefined {
 
   const hasSeries = hasSeriesColumn || hasSeriesLinkTable;
 
+  const hasPagesLinkTable = tableNames.includes("books_pages_link");
+
   const query = `
     SELECT
       b.id,
@@ -186,6 +193,7 @@ export function getBookById(id: number): CalibreBook | undefined {
       GROUP_CONCAT(DISTINCT a.name) as authors,
       ${hasPublisher ? 'p.name' : 'NULL'} as publisher,
       ${hasSeries ? 's.name' : 'NULL'} as series,
+      ${hasPagesLinkTable ? "bpl.pages" : "NULL"} as total_pages,
       GROUP_CONCAT(DISTINCT i.val) as isbn,
       c.text as description,
       r.rating as rating
@@ -199,6 +207,7 @@ export function getBookById(id: number): CalibreBook | undefined {
         ? 'LEFT JOIN books_series_link bsl ON b.id = bsl.book LEFT JOIN series s ON bsl.series = s.id'
         : ''
     }
+    ${hasPagesLinkTable ? 'LEFT JOIN books_pages_link bpl ON b.id = bpl.book' : ''}
     LEFT JOIN identifiers i ON b.id = i.book AND i.type = 'isbn'
     LEFT JOIN comments c ON b.id = c.book
     LEFT JOIN books_ratings_link brl ON b.id = brl.book
@@ -239,6 +248,8 @@ export function searchBooks(query: string): CalibreBook[] {
 
   const hasSeries = hasSeriesColumn || hasSeriesLinkTable;
 
+  const hasPagesLinkTable = tableNames.includes("books_pages_link");
+
   const searchQuery = `
     SELECT
       b.id,
@@ -251,6 +262,7 @@ export function searchBooks(query: string): CalibreBook[] {
       GROUP_CONCAT(DISTINCT a.name) as authors,
       ${hasPublisher ? 'p.name' : 'NULL'} as publisher,
       ${hasSeries ? 's.name' : 'NULL'} as series,
+      ${hasPagesLinkTable ? "bpl.pages" : "NULL"} as total_pages,
       GROUP_CONCAT(DISTINCT i.val) as isbn,
       c.text as description,
       r.rating as rating
@@ -264,6 +276,7 @@ export function searchBooks(query: string): CalibreBook[] {
         ? 'LEFT JOIN books_series_link bsl ON b.id = bsl.book LEFT JOIN series s ON bsl.series = s.id'
         : ''
     }
+    ${hasPagesLinkTable ? "LEFT JOIN books_pages_link bpl ON b.id = bpl.book" : ""}
     LEFT JOIN identifiers i ON b.id = i.book AND i.type = 'isbn'
     LEFT JOIN comments c ON b.id = c.book
     LEFT JOIN books_ratings_link brl ON b.id = brl.book

--- a/lib/sync-service.ts
+++ b/lib/sync-service.ts
@@ -231,6 +231,7 @@ export async function syncCalibreLibrary(
           pubDate: calibreBook.pubdate ? new Date(calibreBook.pubdate) : undefined,
           series: calibreBook.series || null,
           seriesIndex: calibreBook.series_index || null,
+          totalPages: calibreBook.total_pages || null,
           tags,
           path: calibreBook.path,
           description: calibreBook.description || undefined,


### PR DESCRIPTION
Hi, I found out about this project yesterday. I have been setting it up today and trying to migrate my data from Excel (12+ years of readings)

One of the pain points I found is that for each book I had to add the total pages number manually which was quite the chore because I had to go to Calibre to look for it. 
I had been estimating the pages for years with the _Count Pages_ plugin but while investigating how to add this feature, I found out Calibre added a new table **books_pages_link** last December which contains the data (you have to add the column on the calibre list view so it does create and populate the new table).

### What this PR does

- Adds a _total_pages_ field to **CalibreBook** interface.
- On each of the queries that return that interface.
  - Checks that the table exists.
  - Pulls the page number into the new field.
- On the **syncCalibreLibrary** function, when mapping the NewBook object, it maps totalPages from the calibreBook if it exists.

⚠️It does overwrite any value changed manually every time it syncs from Calibre, but if I understood correctly, Calibre's DB is the source of truth so this is not an issue.

I ran the tests and also did a quick check with a copy of my library.

Closes #316 