### PR TITLE
feat: implement tap & hold to select shelf items

### DIFF
--- a/__tests__/hooks/useLongPress.test.ts
+++ b/__tests__/hooks/useLongPress.test.ts
@@ -1,0 +1,608 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useLongPress } from "@/hooks/useLongPress";
+
+describe("useLongPress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("Basic Functionality", () => {
+    it("should return event handlers", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress));
+
+      expect(result.current).toHaveProperty("onMouseDown");
+      expect(result.current).toHaveProperty("onMouseUp");
+      expect(result.current).toHaveProperty("onMouseLeave");
+      expect(result.current).toHaveProperty("onMouseMove");
+      expect(result.current).toHaveProperty("onTouchStart");
+      expect(result.current).toHaveProperty("onTouchEnd");
+      expect(result.current).toHaveProperty("onTouchMove");
+    });
+
+    it("should use default delay and tolerance", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress));
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(499);
+      });
+      expect(onLongPress).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("should accept custom delay and tolerance", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 1000, tolerance: 20 })
+      );
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(999);
+      });
+      expect(onLongPress).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Mouse Events", () => {
+    it("should trigger callback after delay on mouse down", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("should only respond to left mouse button", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      // Right-click (button = 2)
+      const rightClickEvent = {
+        button: 2,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(rightClickEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should cancel on mouse up before delay", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      act(() => {
+        result.current.onMouseUp();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should cancel on mouse leave", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      act(() => {
+        result.current.onMouseLeave();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should cancel on movement beyond tolerance", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(startEvent);
+      });
+
+      // Move beyond tolerance (> 10px)
+      const moveEvent = {
+        clientX: 112,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseMove(moveEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should NOT cancel on movement within tolerance", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(startEvent);
+      });
+
+      // Move within tolerance (< 10px)
+      const moveEvent = {
+        clientX: 105,
+        clientY: 103,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseMove(moveEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Touch Events", () => {
+    it("should trigger callback after delay on touch start", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        touches: [{ clientX: 100, clientY: 100 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("should ignore multi-touch events", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        touches: [
+          { clientX: 100, clientY: 100 },
+          { clientX: 200, clientY: 200 },
+        ],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should cancel on touch end before delay", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        touches: [{ clientX: 100, clientY: 100 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      act(() => {
+        result.current.onTouchEnd();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should cancel on touch move beyond tolerance", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        touches: [{ clientX: 100, clientY: 100 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(startEvent);
+      });
+
+      // Move beyond tolerance (> 10px)
+      const moveEvent = {
+        touches: [{ clientX: 100, clientY: 112 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchMove(moveEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should NOT cancel on touch move within tolerance", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        touches: [{ clientX: 100, clientY: 100 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(startEvent);
+      });
+
+      // Move within tolerance (< 10px)
+      const moveEvent = {
+        touches: [{ clientX: 105, clientY: 103 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchMove(moveEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("should ignore touch move with multiple touches", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        touches: [{ clientX: 100, clientY: 100 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(startEvent);
+      });
+
+      // Multi-touch move
+      const moveEvent = {
+        touches: [
+          { clientX: 105, clientY: 103 },
+          { clientX: 200, clientY: 200 },
+        ],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchMove(moveEvent);
+      });
+
+      // Should still trigger because multi-touch move was ignored
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Memory Management", () => {
+    it("should clear timeout on unmount", () => {
+      const onLongPress = vi.fn();
+      const { result, unmount } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500 })
+      );
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // Unmount before timeout completes
+      unmount();
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // Callback should NOT fire after unmount
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should clear existing timeout when starting new long-press", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const firstEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(firstEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // Start a new long-press before first one completes
+      const secondEvent = {
+        button: 0,
+        clientX: 200,
+        clientY: 200,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(secondEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // First timeout should be cleared, so callback not fired yet
+      expect(onLongPress).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      // Second timeout completes (total 500ms since second start)
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle rapid press and release", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      // Rapid press and release 10 times
+      for (let i = 0; i < 10; i++) {
+        act(() => {
+          result.current.onMouseDown(mockEvent);
+        });
+
+        act(() => {
+          vi.advanceTimersByTime(50);
+        });
+
+        act(() => {
+          result.current.onMouseUp();
+        });
+      }
+
+      // No callbacks should fire
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should not fire if no position set on move", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      // Call onMouseMove without calling onMouseDown first
+      const moveEvent = {
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseMove(moveEvent);
+      });
+
+      // Should not crash or cause issues
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should handle movement exactly at tolerance boundary", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(startEvent);
+      });
+
+      // Move exactly 10px (at boundary)
+      const moveEvent = {
+        clientX: 110,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseMove(moveEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // Should NOT cancel (tolerance is exclusive)
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle diagonal movement correctly", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() =>
+        useLongPress(onLongPress, { delay: 500, tolerance: 10 })
+      );
+
+      const startEvent = {
+        button: 0,
+        clientX: 100,
+        clientY: 100,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseDown(startEvent);
+      });
+
+      // Diagonal move: 8px X, 8px Y (within tolerance individually but not combined)
+      const moveEvent = {
+        clientX: 108,
+        clientY: 108,
+      } as React.MouseEvent;
+
+      act(() => {
+        result.current.onMouseMove(moveEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      // Should still trigger (both deltas < 10)
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/hooks/useLongPress.test.ts
+++ b/__tests__/hooks/useLongPress.test.ts
@@ -23,6 +23,7 @@ describe("useLongPress", () => {
       expect(result.current).toHaveProperty("onMouseMove");
       expect(result.current).toHaveProperty("onTouchStart");
       expect(result.current).toHaveProperty("onTouchEnd");
+      expect(result.current).toHaveProperty("onTouchCancel");
       expect(result.current).toHaveProperty("onTouchMove");
     });
 
@@ -308,6 +309,33 @@ describe("useLongPress", () => {
 
       act(() => {
         result.current.onTouchEnd();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(onLongPress).not.toHaveBeenCalled();
+    });
+
+    it("should cancel on touch cancel (browser-interrupted touch)", () => {
+      const onLongPress = vi.fn();
+      const { result } = renderHook(() => useLongPress(onLongPress, { delay: 500 }));
+
+      const mockEvent = {
+        touches: [{ clientX: 100, clientY: 100 }],
+      } as unknown as React.TouchEvent;
+
+      act(() => {
+        result.current.onTouchStart(mockEvent);
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+
+      act(() => {
+        result.current.onTouchCancel();
       });
 
       act(() => {

--- a/app/shelves/[id]/page.tsx
+++ b/app/shelves/[id]/page.tsx
@@ -375,6 +375,7 @@ export default function ShelfDetailPage() {
               isSelectMode={listView.isSelectMode}
               selectedBookIds={listView.selectedBookIds}
               onToggleSelection={listView.toggleBookSelection}
+              onEnterSelectModeWithSelection={listView.enterSelectModeWithSelection}
               renderActions={!listView.isSelectMode ? (book, index) => (
                 <BookActionsDropdown
                   bookId={book.id}
@@ -396,6 +397,7 @@ export default function ShelfDetailPage() {
                   isSelectMode={listView.isSelectMode}
                   isSelected={listView.selectedBookIds.has(book.id)}
                   onToggleSelection={() => listView.toggleBookSelection(book.id)}
+                  onLongPress={() => listView.enterSelectModeWithSelection(book.id)}
                   actions={
                     !listView.isSelectMode ? (
                       <BookActionsDropdown

--- a/components/Books/BookListItem.tsx
+++ b/components/Books/BookListItem.tsx
@@ -63,6 +63,14 @@ export const BookListItem = memo(function BookListItem({
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Allow Space key to trigger long-press selection when not in select mode
+    if (e.key === ' ' && !isSelectMode && onLongPress) {
+      e.preventDefault();
+      onLongPress();
+    }
+  };
+
   // Long-press handlers (only active when NOT in select mode)
   const longPressHandlers = useLongPress(
     () => {
@@ -75,6 +83,9 @@ export const BookListItem = memo(function BookListItem({
 
   return (
     <div
+      role={onLongPress && !isSelectMode ? "button" : undefined}
+      aria-label={onLongPress && !isSelectMode ? `${book.title}. Press Space or long-press to select.` : undefined}
+      tabIndex={onLongPress && !isSelectMode ? 0 : undefined}
       className={cn(
         "bg-[var(--card-bg)] border rounded-lg p-4 transition-all",
         isSelectMode && "cursor-pointer hover:shadow-md",
@@ -84,6 +95,7 @@ export const BookListItem = memo(function BookListItem({
         className
       )}
       onClick={isSelectMode ? handleClick : onClick}
+      onKeyDown={handleKeyDown}
       {...(!isSelectMode && onLongPress ? longPressHandlers : {})}
     >
       <div className="flex gap-4 items-start">

--- a/components/Books/BookListItem.tsx
+++ b/components/Books/BookListItem.tsx
@@ -9,6 +9,7 @@ import { StatusBadge } from "@/components/Utilities/StatusBadge";
 import { StarRating } from "@/components/Utilities/StarRating";
 import { type BookStatus } from "@/utils/statusConfig";
 import { getCoverUrl } from "@/lib/utils/cover-url";
+import { useLongPress } from "@/hooks/useLongPress";
 
 interface BookListItemProps {
   book: {
@@ -30,6 +31,7 @@ interface BookListItemProps {
   isSelectMode?: boolean;
   isSelected?: boolean;
   onToggleSelection?: () => void;
+  onLongPress?: () => void;
 }
 
 export const BookListItem = memo(function BookListItem({
@@ -41,6 +43,7 @@ export const BookListItem = memo(function BookListItem({
   isSelectMode = false,
   isSelected = false,
   onToggleSelection,
+  onLongPress,
 }: BookListItemProps) {
   const [imageError, setImageError] = useState(false);
 
@@ -60,6 +63,16 @@ export const BookListItem = memo(function BookListItem({
     }
   };
 
+  // Long-press handlers (only active when NOT in select mode)
+  const longPressHandlers = useLongPress(
+    () => {
+      if (!isSelectMode && onLongPress) {
+        onLongPress();
+      }
+    },
+    { delay: 500, tolerance: 10 }
+  );
+
   return (
     <div
       className={cn(
@@ -71,6 +84,7 @@ export const BookListItem = memo(function BookListItem({
         className
       )}
       onClick={isSelectMode ? handleClick : onClick}
+      {...(!isSelectMode && onLongPress ? longPressHandlers : {})}
     >
       <div className="flex gap-4 items-start">
         {/* Checkbox for select mode */}

--- a/components/Books/BookListItem.tsx
+++ b/components/Books/BookListItem.tsx
@@ -64,8 +64,9 @@ export const BookListItem = memo(function BookListItem({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    // Allow Space key to trigger long-press selection when not in select mode
-    if (e.key === ' ' && !isSelectMode && onLongPress) {
+    // Allow Space and Enter keys to trigger long-press selection when not in select mode
+    // role="button" per ARIA spec requires both Space and Enter to activate
+    if ((e.key === ' ' || e.key === 'Enter') && !isSelectMode && onLongPress) {
       e.preventDefault();
       onLongPress();
     }
@@ -84,7 +85,7 @@ export const BookListItem = memo(function BookListItem({
   return (
     <div
       role={onLongPress && !isSelectMode ? "button" : undefined}
-      aria-label={onLongPress && !isSelectMode ? `${book.title}. Press Space or long-press to select.` : undefined}
+      aria-label={onLongPress && !isSelectMode ? `${book.title}. Press Enter or Space to select.` : undefined}
       tabIndex={onLongPress && !isSelectMode ? 0 : undefined}
       className={cn(
         "bg-[var(--card-bg)] border rounded-lg p-4 transition-all",

--- a/components/Books/DraggableBookList.tsx
+++ b/components/Books/DraggableBookList.tsx
@@ -46,6 +46,7 @@ interface DraggableBookListProps {
   isSelectMode?: boolean;
   selectedBookIds?: Set<number>;
   onToggleSelection?: (bookId: number) => void;
+  onEnterSelectModeWithSelection?: (bookId: number) => void;
 }
 
 interface SortableBookItemProps {
@@ -54,9 +55,10 @@ interface SortableBookItemProps {
   isSelectMode?: boolean;
   isSelected?: boolean;
   onToggleSelection?: () => void;
+  onLongPress?: () => void;
 }
 
-function SortableBookItem({ book, actions, isSelectMode = false, isSelected = false, onToggleSelection }: SortableBookItemProps) {
+function SortableBookItem({ book, actions, isSelectMode = false, isSelected = false, onToggleSelection, onLongPress }: SortableBookItemProps) {
   const {
     attributes,
     listeners,
@@ -101,6 +103,7 @@ function SortableBookItem({ book, actions, isSelectMode = false, isSelected = fa
             isSelectMode={isSelectMode}
             isSelected={isSelected}
             onToggleSelection={onToggleSelection}
+            onLongPress={onLongPress}
           />
         </div>
       </div>
@@ -116,6 +119,7 @@ export function DraggableBookList({
   isSelectMode = false,
   selectedBookIds = new Set(),
   onToggleSelection,
+  onEnterSelectModeWithSelection,
 }: DraggableBookListProps) {
   const [activeId, setActiveId] = useState<number | null>(null);
   const [localBooks, setLocalBooks] = useState(books);
@@ -190,6 +194,7 @@ export function DraggableBookList({
             isSelectMode={isSelectMode}
             isSelected={selectedBookIds.has(book.id)}
             onToggleSelection={() => onToggleSelection?.(book.id)}
+            onLongPress={() => onEnterSelectModeWithSelection?.(book.id)}
           />
         ))}
       </div>
@@ -214,6 +219,7 @@ export function DraggableBookList({
               isSelectMode={isSelectMode}
               isSelected={selectedBookIds.has(book.id)}
               onToggleSelection={() => onToggleSelection?.(book.id)}
+              onLongPress={() => onEnterSelectModeWithSelection?.(book.id)}
             />
           ))}
         </div>

--- a/hooks/useBookListView.ts
+++ b/hooks/useBookListView.ts
@@ -94,6 +94,12 @@ export function useBookListView({ books, initialFilter = "" }: UseBookListViewOp
     setSelectedBookIds(new Set());
   }, []);
 
+  // Enter select mode and select a specific book (for long-press to select)
+  const enterSelectModeWithSelection = useCallback((bookId: number) => {
+    setIsSelectMode(true);
+    setSelectedBookIds(new Set([bookId]));
+  }, []);
+
   return {
     // Mobile detection
     isMobile,
@@ -111,5 +117,6 @@ export function useBookListView({ books, initialFilter = "" }: UseBookListViewOp
     toggleSelectAll,
     clearSelection,
     exitSelectMode,
+    enterSelectModeWithSelection,
   };
 }

--- a/hooks/useLongPress.ts
+++ b/hooks/useLongPress.ts
@@ -112,6 +112,10 @@ export function useLongPress(
     cancel();
   }, [cancel]);
 
+  const onTouchCancel = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
   const onTouchMove = useCallback(
     (e: React.TouchEvent) => {
       if (e.touches.length !== 1) return;
@@ -137,6 +141,7 @@ export function useLongPress(
     onMouseMove,
     onTouchStart,
     onTouchEnd,
+    onTouchCancel,
     onTouchMove,
   };
 }

--- a/hooks/useLongPress.ts
+++ b/hooks/useLongPress.ts
@@ -9,7 +9,7 @@
  * @returns Event handlers to spread onto target element
  */
 
-import { useRef, useCallback } from "react";
+import { useRef, useCallback, useEffect } from "react";
 
 interface UseLongPressOptions {
   /** Delay in milliseconds before triggering long-press (default: 500) */
@@ -120,6 +120,15 @@ export function useLongPress(
     },
     [checkMovement]
   );
+
+  // Cleanup timeout on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return {
     onMouseDown,

--- a/hooks/useLongPress.ts
+++ b/hooks/useLongPress.ts
@@ -1,0 +1,133 @@
+/**
+ * useLongPress Hook
+ * 
+ * Detects long-press gestures on touch and mouse events.
+ * Used for entering select mode when user long-presses on a book list item.
+ * 
+ * @param onLongPress - Callback fired when long-press is detected
+ * @param options - Configuration options
+ * @returns Event handlers to spread onto target element
+ */
+
+import { useRef, useCallback } from "react";
+
+interface UseLongPressOptions {
+  /** Delay in milliseconds before triggering long-press (default: 500) */
+  delay?: number;
+  /** Movement tolerance in pixels - if exceeded, cancels long-press (default: 10) */
+  tolerance?: number;
+}
+
+interface Position {
+  x: number;
+  y: number;
+}
+
+export function useLongPress(
+  onLongPress: () => void,
+  options: UseLongPressOptions = {}
+) {
+  const { delay = 500, tolerance = 10 } = options;
+
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const startPosRef = useRef<Position | null>(null);
+
+  const start = useCallback(
+    (x: number, y: number) => {
+      startPosRef.current = { x, y };
+
+      // Clear any existing timeout
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      // Set new timeout for long-press
+      timeoutRef.current = setTimeout(() => {
+        onLongPress();
+        startPosRef.current = null;
+      }, delay);
+    },
+    [onLongPress, delay]
+  );
+
+  const cancel = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    startPosRef.current = null;
+  }, []);
+
+  const checkMovement = useCallback(
+    (x: number, y: number) => {
+      if (!startPosRef.current) return;
+
+      const deltaX = Math.abs(x - startPosRef.current.x);
+      const deltaY = Math.abs(y - startPosRef.current.y);
+
+      // If movement exceeds tolerance, cancel long-press
+      if (deltaX > tolerance || deltaY > tolerance) {
+        cancel();
+      }
+    },
+    [tolerance, cancel]
+  );
+
+  // Mouse event handlers
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Only respond to left mouse button
+      if (e.button !== 0) return;
+      start(e.clientX, e.clientY);
+    },
+    [start]
+  );
+
+  const onMouseUp = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const onMouseLeave = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      checkMovement(e.clientX, e.clientY);
+    },
+    [checkMovement]
+  );
+
+  // Touch event handlers
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (e.touches.length !== 1) return; // Only single-touch
+      const touch = e.touches[0];
+      start(touch.clientX, touch.clientY);
+    },
+    [start]
+  );
+
+  const onTouchEnd = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (e.touches.length !== 1) return;
+      const touch = e.touches[0];
+      checkMovement(touch.clientX, touch.clientY);
+    },
+    [checkMovement]
+  );
+
+  return {
+    onMouseDown,
+    onMouseUp,
+    onMouseLeave,
+    onMouseMove,
+    onTouchStart,
+    onTouchEnd,
+    onTouchMove,
+  };
+}


### PR DESCRIPTION
## Summary

Implements tap & hold gesture to enter select mode on shelf items, eliminating the need to scroll to the top to press the "Select" button.

**Key Features:**
- Long-press (500ms) on book card body enters select mode and auto-selects the item
- Separate touch targets: drag handle (200ms) vs card body (500ms) to avoid conflicts
- 10px movement tolerance to prevent activation during scrolling
- Mobile-focused UX improvement

**Resolves:** #414

---

## Changes

### New Files
- **`hooks/useLongPress.ts`** - Reusable long-press detection hook
  - Configurable delay (default 500ms)
  - Touch and mouse event support
  - Movement tolerance to distinguish from scrolling

### Modified Files
- **`hooks/useBookListView.ts`** - Added `enterSelectModeWithSelection(bookId)` function
- **`components/Books/BookListItem.tsx`** - Integrated long-press handlers on card body
- **`components/Books/DraggableBookList.tsx`** - Passes long-press handler to items
- **`app/shelves/[id]/page.tsx`** - Wires up new functionality on mobile list views

---

## Technical Details

### Touch Target Separation
- **Drag Handle (left side):** Long-press 200ms → Triggers drag-and-drop
- **Book Card Body:** Long-press 500ms → Enters select mode + selects item

This eliminates timing conflicts between drag and select gestures.

### Behavior
1. User long-presses on book card (NOT in select mode)
2. After 500ms: enters select mode + selects that book
3. BulkActionBar appears at bottom
4. User can tap other books to select/deselect
5. Existing "Select" button still works

### Safeguards
- Long-press handlers only active when NOT already in select mode
- 10px movement tolerance cancels long-press (allows smooth scrolling)
- Drag handles unchanged (keep existing 200ms drag behavior)
- Desktop tables unchanged (not needed for desktop UX)

---

## Testing

✅ **All 4013 tests pass**

### Manual Testing Checklist
- [ ] Long-press on book card body enters select mode + selects item
- [ ] Long-press on drag handle still triggers drag-and-drop
- [ ] Quick tap on book card still navigates to detail page
- [ ] Scrolling doesn't accidentally trigger selection (10px tolerance)
- [ ] In select mode, long-press is disabled (tap to select/deselect)
- [ ] BulkActionBar appears/works correctly
- [ ] Desktop tables unaffected

---

## Mobile UX Benefits

**Before:** User must scroll to top → press "Select" button → scroll back down → select items

**After:** User long-presses on any item → immediately in select mode with that item selected → continue selecting

Much faster and more intuitive, especially on mobile devices.