### PR TITLE
Fix: DNF books not appearing in library filter

### DIFF
--- a/__tests__/integration/repositories/books/book-status-filtering.test.ts
+++ b/__tests__/integration/repositories/books/book-status-filtering.test.ts
@@ -1,0 +1,343 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { bookRepository } from "@/lib/repositories";
+import { sessionRepository } from "@/lib/repositories/session.repository";
+import { setupTestDatabase, teardownTestDatabase, clearTestDatabase } from "@/__tests__/helpers/db-setup";
+import { createTestBook } from "../../../fixtures/test-data";
+
+/**
+ * BookRepository Status Filtering Tests
+ * 
+ * Tests status filtering in findWithFilters() and findWithFiltersAndRelations() methods.
+ * 
+ * Key behaviors:
+ * - "read" and "dnf" statuses are terminal states - should include all sessions (is_active can be 0 or 1)
+ * - "to-read", "read-next", "reading" statuses should only include active sessions (is_active = 1)
+ * 
+ * This tests the fix for the DNF filter bug where DNF books were not showing up
+ * because the code was requiring is_active = 1 for DNF status.
+ */
+
+beforeAll(async () => {
+  await setupTestDatabase(__filename);
+});
+
+afterAll(async () => {
+  await teardownTestDatabase(__filename);
+});
+
+beforeEach(async () => {
+  await clearTestDatabase(__filename);
+});
+
+describe("BookRepository Status Filter - Terminal States", () => {
+  test("should filter books by 'read' status (terminal state)", async () => {
+    // Arrange: Create books with different statuses
+    const readBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "Finished Book",
+      authors: ["Author 1"],
+      path: "Author 1/Finished Book (1)",
+    }));
+
+    const readingBook = await bookRepository.create(createTestBook({
+      calibreId: 2,
+      title: "Currently Reading",
+      authors: ["Author 2"],
+      path: "Author 2/Currently Reading (2)",
+    }));
+
+    // Create read session (inactive)
+    await sessionRepository.create({
+      bookId: readBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "read",
+      isActive: false, // Read sessions are inactive
+      startedDate: "2026-01-01",
+      completedDate: "2026-01-15",
+    });
+
+    // Create reading session (active)
+    await sessionRepository.create({
+      bookId: readingBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "reading",
+      isActive: true,
+    });
+
+    // Act: Filter by 'read' status
+    const result = await bookRepository.findWithFilters({ status: "read" }, 50, 0);
+
+    // Assert: Should only return the read book
+    expect(result.books).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.books[0].id).toBe(readBook.id);
+  });
+
+  test("should filter books by 'dnf' status (terminal state)", async () => {
+    // Arrange: Create books with different statuses
+    const dnfBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "DNF Book",
+      authors: ["Author 1"],
+      path: "Author 1/DNF Book (1)",
+    }));
+
+    const readingBook = await bookRepository.create(createTestBook({
+      calibreId: 2,
+      title: "Currently Reading",
+      authors: ["Author 2"],
+      path: "Author 2/Currently Reading (2)",
+    }));
+
+    // Create DNF session (inactive)
+    await sessionRepository.create({
+      bookId: dnfBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "dnf",
+      isActive: false, // DNF sessions are inactive
+      startedDate: "2026-01-01",
+    });
+
+    // Create reading session (active)
+    await sessionRepository.create({
+      bookId: readingBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "reading",
+      isActive: true,
+    });
+
+    // Act: Filter by 'dnf' status
+    const result = await bookRepository.findWithFilters({ status: "dnf" }, 50, 0);
+
+    // Assert: Should only return the DNF book
+    expect(result.books).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.books[0].id).toBe(dnfBook.id);
+  });
+
+  test("should include DNF books even when is_active = 0", async () => {
+    // Arrange: Create a DNF book with inactive session
+    const dnfBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "DNF Book Inactive",
+      authors: ["Author 1"],
+      path: "Author 1/DNF Book Inactive (1)",
+    }));
+
+    // Create DNF session with is_active = 0 (archived)
+    await sessionRepository.create({
+      bookId: dnfBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "dnf",
+      isActive: false, // This is the critical test - DNF sessions should be inactive
+      startedDate: "2026-01-01",
+    });
+
+    // Act: Filter by 'dnf' status
+    const result = await bookRepository.findWithFilters({ status: "dnf" }, 50, 0);
+
+    // Assert: Should return the DNF book
+    expect(result.books).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.books[0].id).toBe(dnfBook.id);
+  });
+
+  test("should handle book with both DNF and active session", async () => {
+    // Arrange: Create a book that was DNF'd and then added back
+    const book = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "Book with Multiple Sessions",
+      authors: ["Author 1"],
+      path: "Author 1/Book with Multiple Sessions (1)",
+    }));
+
+    // First session: DNF (inactive)
+    await sessionRepository.create({
+      bookId: book.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "dnf",
+      isActive: false,
+      startedDate: "2026-01-01",
+    });
+
+    // Second session: read-next (active)
+    await sessionRepository.create({
+      bookId: book.id,
+      userId: null,
+      sessionNumber: 2,
+      status: "read-next",
+      isActive: true,
+    });
+
+    // Act: Filter by 'dnf' status
+    const dnfResult = await bookRepository.findWithFilters({ status: "dnf" }, 50, 0);
+
+    // Assert: Should return the book (it has a DNF session)
+    expect(dnfResult.books).toHaveLength(1);
+    expect(dnfResult.total).toBe(1);
+    expect(dnfResult.books[0].id).toBe(book.id);
+
+    // Also verify it appears in read-next filter
+    const readNextResult = await bookRepository.findWithFilters({ status: "read-next" }, 50, 0);
+    expect(readNextResult.books).toHaveLength(1);
+    expect(readNextResult.books[0].id).toBe(book.id);
+  });
+});
+
+describe("BookRepository Status Filter - Active States", () => {
+  test("should filter books by 'reading' status (only active sessions)", async () => {
+    // Arrange: Create books
+    const activeBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "Active Reading",
+      authors: ["Author 1"],
+      path: "Author 1/Active Reading (1)",
+    }));
+
+    const inactiveBook = await bookRepository.create(createTestBook({
+      calibreId: 2,
+      title: "Inactive Reading",
+      authors: ["Author 2"],
+      path: "Author 2/Inactive Reading (2)",
+    }));
+
+    // Create active reading session
+    await sessionRepository.create({
+      bookId: activeBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "reading",
+      isActive: true,
+    });
+
+    // Create inactive reading session (edge case - shouldn't happen in practice)
+    await sessionRepository.create({
+      bookId: inactiveBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "reading",
+      isActive: false,
+    });
+
+    // Act: Filter by 'reading' status
+    const result = await bookRepository.findWithFilters({ status: "reading" }, 50, 0);
+
+    // Assert: Should only return the active reading book
+    expect(result.books).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.books[0].id).toBe(activeBook.id);
+  });
+
+  test("should filter books by 'to-read' status (only active sessions)", async () => {
+    // Arrange
+    const activeBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "Active To-Read",
+      authors: ["Author 1"],
+      path: "Author 1/Active To-Read (1)",
+    }));
+
+    await sessionRepository.create({
+      bookId: activeBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "to-read",
+      isActive: true,
+    });
+
+    // Act
+    const result = await bookRepository.findWithFilters({ status: "to-read" }, 50, 0);
+
+    // Assert
+    expect(result.books).toHaveLength(1);
+    expect(result.books[0].id).toBe(activeBook.id);
+  });
+
+  test("should filter books by 'read-next' status (only active sessions)", async () => {
+    // Arrange
+    const activeBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "Active Read-Next",
+      authors: ["Author 1"],
+      path: "Author 1/Active Read-Next (1)",
+    }));
+
+    await sessionRepository.create({
+      bookId: activeBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "read-next",
+      isActive: true,
+    });
+
+    // Act
+    const result = await bookRepository.findWithFilters({ status: "read-next" }, 50, 0);
+
+    // Assert
+    expect(result.books).toHaveLength(1);
+    expect(result.books[0].id).toBe(activeBook.id);
+  });
+});
+
+describe("BookRepository Status Filter - findWithFiltersAndRelations()", () => {
+  test("should filter books by 'dnf' status using findWithFiltersAndRelations", async () => {
+    // Arrange: Create DNF book
+    const dnfBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "DNF Book",
+      authors: ["Author 1"],
+      path: "Author 1/DNF Book (1)",
+    }));
+
+    await sessionRepository.create({
+      bookId: dnfBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "dnf",
+      isActive: false,
+      startedDate: "2026-01-01",
+    });
+
+    // Act: Filter using findWithFiltersAndRelations
+    const result = await bookRepository.findWithFiltersAndRelations({ status: "dnf" }, 50, 0);
+
+    // Assert
+    expect(result.books).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.books[0].id).toBe(dnfBook.id);
+  });
+
+  test("should filter books by 'read' status using findWithFiltersAndRelations", async () => {
+    // Arrange: Create read book
+    const readBook = await bookRepository.create(createTestBook({
+      calibreId: 1,
+      title: "Read Book",
+      authors: ["Author 1"],
+      path: "Author 1/Read Book (1)",
+    }));
+
+    await sessionRepository.create({
+      bookId: readBook.id,
+      userId: null,
+      sessionNumber: 1,
+      status: "read",
+      isActive: false,
+      startedDate: "2026-01-01",
+      completedDate: "2026-01-15",
+    });
+
+    // Act
+    const result = await bookRepository.findWithFiltersAndRelations({ status: "read" }, 50, 0);
+
+    // Assert
+    expect(result.books).toHaveLength(1);
+    expect(result.total).toBe(1);
+    expect(result.books[0].id).toBe(readBook.id);
+  });
+});

--- a/lib/repositories/book.repository.ts
+++ b/lib/repositories/book.repository.ts
@@ -375,8 +375,8 @@ export class BookRepository extends BaseRepository<Book, NewBook, typeof books> 
     if (filters.status) {
       const statusCondition = eq(readingSessions.status, filters.status as any);
       const activeCondition =
-        filters.status === "read"
-          ? undefined // For "read", include all sessions
+        filters.status === "read" || filters.status === "dnf"
+          ? undefined // For terminal states (read, dnf), include all sessions
           : eq(readingSessions.isActive, true);
 
       const sessionQuery = this.getDatabase()
@@ -752,8 +752,8 @@ export class BookRepository extends BaseRepository<Book, NewBook, typeof books> 
     if (filters.status) {
       const statusCondition = eq(readingSessions.status, filters.status as any);
       const activeCondition =
-        filters.status === "read"
-          ? undefined // For "read", include all sessions
+        filters.status === "read" || filters.status === "dnf"
+          ? undefined // For terminal states (read, dnf), include all sessions
           : eq(readingSessions.isActive, true);
 
       const sessionQuery = this.getDatabase()


### PR DESCRIPTION
## Summary

Fixes critical bug where books with DNF (Did Not Finish) status were not showing up when filtering by status on the library page.

## Root Cause

The book repository was incorrectly treating DNF status like active statuses (reading, to-read, read-next) by requiring `is_active = 1`. However, DNF is a terminal/completed state like "read", where sessions are archived with `is_active = 0`.

**Before**: DNF filter returned 0 books despite 3 DNF books existing in the database  
**After**: DNF filter correctly returns all 3 DNF books

## Changes

### Repository Logic (`lib/repositories/book.repository.ts`)
- Updated `findWithFilters()` to treat 'dnf' status like 'read' status (lines 377-380)
- Updated `findWithFiltersAndRelations()` to treat 'dnf' status like 'read' status (lines 754-757)
- Terminal states (read, dnf) now include all sessions regardless of `is_active`
- Active states (reading, to-read, read-next) still require `is_active = 1`

### Test Coverage (`__tests__/integration/repositories/books/book-status-filtering.test.ts`)
Added 9 comprehensive tests covering:
- ✅ DNF status filtering (terminal state)
- ✅ Read status filtering (terminal state)
- ✅ Active status filtering (reading, to-read, read-next)
- ✅ Books with multiple sessions (DNF + active)
- ✅ Both `findWithFilters()` and `findWithFiltersAndRelations()` methods

## Testing

- All 4,022 existing tests pass ✅
- 9 new tests added for status filtering ✅
- Verified via API: `/api/books?status=dnf` returns 3 books ✅
- Confirmed database has 3 DNF sessions with `is_active = 0` ✅

## Impact

- Users can now filter for DNF books on the library page
- Fixes incorrect behavior where terminal states were treated as active states
- No breaking changes to other status filters

## Database Evidence

```sql
-- Before fix: 3 DNF sessions exist with is_active = 0
sqlite> SELECT status, is_active, COUNT(*) FROM reading_sessions 
        GROUP BY status, is_active;
dnf|0|3
read|0|66
read|1|2
read-next|1|35
reading|1|3
to-read|1|915
```

## Related Files

- `lib/repositories/book.repository.ts` (2 locations updated)
- `__tests__/integration/repositories/books/book-status-filtering.test.ts` (new file)